### PR TITLE
Refactor Training Lab CSS code and enable wrapping

### DIFF
--- a/src/lab_common.h
+++ b/src/lab_common.h
@@ -535,7 +535,6 @@ typedef struct ImportData
     FileInfo *file_info;  // pointer to file info array
     ExportHeader *header; // pointer to header array for the files on the current page
     u8 page;              // file page
-    u8 files_on_page;     // number of files on the current page
     struct
     {
         GOBJ *gobj; // confirm gobj

--- a/src/lab_common.h
+++ b/src/lab_common.h
@@ -520,8 +520,6 @@ typedef struct ImportData
     u8 menu_state;
     u8 cursor;
     u8 memcard_inserted[2];     // memcard inserted bools
-    u16 memcard_free_files[2];  // free files on this card
-    u16 memcard_free_blocks[2]; // free blocks on this card
     u16 memcard_slot;           // selected slot
     JOBJ *memcard_jobj[2];
     JOBJ *screenshot_jobj;

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -793,7 +793,6 @@ int Menu_SelFile_LoadPage(GOBJ *menu_gobj, int page)
     int files_on_page = IMPORT_FILESPERPAGE;
     if (page == page_total - 1)
         files_on_page = import_data.file_num % IMPORT_FILESPERPAGE;
-    import_data.files_on_page = files_on_page;
 
     // cancel card read if in progress
     int memcard_status = Memcard_CheckStatus();
@@ -971,8 +970,7 @@ void Menu_SelFile_LoadAsyncThink(GOBJ *menu_gobj)
     }
 
     // check if any pending files to load
-    if ((import_data.snap.load_inprogress == 0) && // checking inprogress again in case the code above set it to 0 this tick
-        (import_data.snap.loaded_num < import_data.files_on_page))
+    if (import_data.snap.load_inprogress == 0) // checking inprogress again in case the code above set it to 0 this tick
     {
 
         // find nearest unloaded file

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -973,47 +973,18 @@ void Menu_SelFile_LoadAsyncThink(GOBJ *menu_gobj)
     if (import_data.snap.load_inprogress == 0) // checking inprogress again in case the code above set it to 0 this tick
     {
 
-        // find nearest unloaded file
         int file_to_load;
         int cursor = import_data.cursor;
 
         // check if cursor is loaded
         if (import_data.snap.is_loaded[cursor] == 0)
             file_to_load = cursor;
-        // find nearest unloaded file
+        else if (cursor < IMPORT_FILESPERPAGE - 1 && import_data.snap.is_loaded[cursor + 1] == 0)
+            file_to_load = cursor + 1;
+        else if (cursor > 0 && import_data.snap.is_loaded[cursor - 1] == 0)
+            file_to_load = cursor - 1;
         else
-        {
-            // search for unloaded snap nearest to the cursor
-            int search_up = cursor;
-            int search_down = cursor;
-            for (int i = 0; i < (IMPORT_FILESPERPAGE - 1); i++)
-            {
-                search_up--;
-                search_down++;
-
-                // if still on page
-                if (search_up >= 0)
-                {
-                    if (import_data.snap.is_loaded[search_up] == 0)
-                    {
-                        // load this next
-                        file_to_load = search_up;
-                        break;
-                    }
-                }
-
-                // if still on page
-                if (search_down < IMPORT_FILESPERPAGE)
-                {
-                    if (import_data.snap.is_loaded[search_down] == 0)
-                    {
-                        // load this next
-                        file_to_load = search_down;
-                        break;
-                    }
-                }
-            }
-        }
+            return;
 
         // get filename and size for this file
         int this_file_index = (import_data.page * IMPORT_FILESPERPAGE) + file_to_load; // page file index -> TMREC file index

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -485,7 +485,6 @@ void Menu_SelFile_Init(GOBJ *menu_gobj)
     import_data.cursor = 0;
     import_data.page = 0;
 
-    // show memcards
     JOBJ_ClearFlagsAll(import_data.scroll_jobj, JOBJ_HIDDEN);
     JOBJ_ClearFlagsAll(import_data.screenshot_jobj, JOBJ_HIDDEN);
 
@@ -535,7 +534,7 @@ void Menu_SelFile_Init(GOBJ *menu_gobj)
     Text_SetText(import_data.title_text, 0, "Select Recording");
 
     // edit description
-    Text_SetText(import_data.desc_text, 0, "A = Select          B = Return          X = Delete");
+    Text_SetText(import_data.desc_text, 0, "A = Select   B = Return   X = Delete   Left/Right = Prev/Next Page");
 
     // search card for save files
     import_data.file_num = 0;

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -563,29 +563,22 @@ void Menu_SelFile_Init(GOBJ *menu_gobj)
                     // search for files with name TMREC
                     for (int i = 0; i < CARD_MAX_FILE; i++)
                     {
-
                         CARDStat card_stat;
 
-                        if (CARDGetStatus(slot, i, &card_stat) == CARD_RESULT_READY)
-                        {
-                            // check company code
-                            if (strncmp(os_info->company, card_stat.company, sizeof(os_info->company)) == 0)
-                            {
-                                // check game name
-                                if (strncmp(os_info->gameName, card_stat.gameName, sizeof(os_info->gameName)) == 0)
-                                {
-                                    // check file name
-                                    if (strncmp("TMREC", card_stat.fileName, 5) == 0)
-                                    {
-                                        OSReport("found recording file %s with size %d\n", card_stat.fileName, card_stat.length);
-                                        import_data.file_info[import_data.file_num].file_size = card_stat.length;                                      // save file size
-                                        import_data.file_info[import_data.file_num].file_no = i;                                                       // save file no
-                                        memcpy(import_data.file_info[import_data.file_num].file_name, card_stat.fileName, sizeof(card_stat.fileName)); // save file name
-                                        import_data.file_num++;                                                                                        // increment file amount
-                                    }
-                                }
-                            }
-                        }
+                        if (CARDGetStatus(slot, i, &card_stat) != CARD_RESULT_READY)
+                            continue;
+
+                        // check file matches expectations
+                        if (strncmp(os_info->company, card_stat.company, sizeof(os_info->company)) != 0 ||
+                                strncmp(os_info->gameName, card_stat.gameName, sizeof(os_info->gameName)) != 0 ||
+                                strncmp("TMREC", card_stat.fileName, 5) != 0)
+                            continue;
+
+                        OSReport("found recording file %s with size %d\n", card_stat.fileName, card_stat.length);
+                        import_data.file_info[import_data.file_num].file_size = card_stat.length;                                      // save file size
+                        import_data.file_info[import_data.file_num].file_no = i;                                                       // save file no
+                        memcpy(import_data.file_info[import_data.file_num].file_name, card_stat.fileName, sizeof(card_stat.fileName)); // save file name
+                        import_data.file_num++;                                                                                        // increment file amount
                     }
                 }
             }

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -405,22 +405,7 @@ void Menu_SelCard_Think(GOBJ *menu_gobj)
     }
 
     // cursor movement
-    if (down & (HSD_BUTTON_LEFT | HSD_BUTTON_DPAD_LEFT)) // check for cursor left
-    {
-        if (import_data.cursor > 0)
-        {
-            import_data.cursor--;
-            SFX_PlayCommon(2);
-        }
-    }
-    else if (down & (HSD_BUTTON_RIGHT | HSD_BUTTON_DPAD_RIGHT)) // check for cursor right
-    {
-        if (import_data.cursor < 1)
-        {
-            import_data.cursor++;
-            SFX_PlayCommon(2);
-        }
-    }
+    Menu_Left_Right(down, &import_data.cursor);
 
     // highlight cursor
     for (int i = 0; i < 2; i++)
@@ -1239,6 +1224,31 @@ void Menu_Confirm_Init(GOBJ *menu_gobj, int kind)
 
     return;
 }
+
+void Menu_Left_Right(int down, u8* cursor)
+{
+    if (*cursor < 0 || import_data.confirm.cursor > 1)
+        assert("cursor out of bounds");
+
+    // cursor movement
+    if (down & (HSD_BUTTON_RIGHT | HSD_BUTTON_DPAD_RIGHT)) // check for cursor right
+    {
+        if (*cursor == 0)
+        {
+            *cursor = 1;
+            SFX_PlayCommon(2);
+        }
+    }
+    else if (down & (HSD_BUTTON_LEFT | HSD_BUTTON_DPAD_LEFT)) // check for cursor down
+    {
+        if (*cursor == 1)
+        {
+            *cursor = 0;
+            SFX_PlayCommon(2);
+        }
+    }
+}
+
 void Menu_Confirm_Think(GOBJ *menu_gobj)
 {
 
@@ -1254,23 +1264,7 @@ void Menu_Confirm_Think(GOBJ *menu_gobj)
     {
     case (CFRM_LOAD):
     {
-        // cursor movement
-        if (down & (HSD_BUTTON_RIGHT | HSD_BUTTON_DPAD_RIGHT)) // check for cursor right
-        {
-            if (import_data.confirm.cursor < 1)
-            {
-                import_data.confirm.cursor++;
-                SFX_PlayCommon(2);
-            }
-        }
-        else if (down & (HSD_BUTTON_LEFT | HSD_BUTTON_DPAD_LEFT)) // check for cursor down
-        {
-            if (import_data.confirm.cursor > 0)
-            {
-                import_data.confirm.cursor--;
-                SFX_PlayCommon(2);
-            }
-        }
+        Menu_Left_Right(down, &import_data.confirm.cursor);
 
         // highlight cursor
         int cursor = import_data.confirm.cursor;
@@ -1380,24 +1374,7 @@ void Menu_Confirm_Think(GOBJ *menu_gobj)
     }
     case (CFRM_DEL):
     {
-
-        // cursor movement
-        if (down & (HSD_BUTTON_RIGHT | HSD_BUTTON_DPAD_RIGHT)) // check for cursor right
-        {
-            if (import_data.confirm.cursor < 1)
-            {
-                import_data.confirm.cursor++;
-                SFX_PlayCommon(2);
-            }
-        }
-        else if (down & (HSD_BUTTON_LEFT | HSD_BUTTON_DPAD_LEFT)) // check for cursor down
-        {
-            if (import_data.confirm.cursor > 0)
-            {
-                import_data.confirm.cursor--;
-                SFX_PlayCommon(2);
-            }
-        }
+        Menu_Left_Right(down, &import_data.confirm.cursor);
 
         // highlight cursor
         int cursor = import_data.confirm.cursor;
@@ -1442,24 +1419,7 @@ void Menu_Confirm_Think(GOBJ *menu_gobj)
     }
     case (CFRM_ERR):
     {
-
-        // cursor movement
-        if (down & (HSD_BUTTON_RIGHT | HSD_BUTTON_DPAD_RIGHT)) // check for cursor right
-        {
-            if (import_data.confirm.cursor < 1)
-            {
-                import_data.confirm.cursor++;
-                SFX_PlayCommon(2);
-            }
-        }
-        else if (down & (HSD_BUTTON_LEFT | HSD_BUTTON_DPAD_LEFT)) // check for cursor down
-        {
-            if (import_data.confirm.cursor > 0)
-            {
-                import_data.confirm.cursor--;
-                SFX_PlayCommon(2);
-            }
-        }
+        Menu_Left_Right(down, &import_data.confirm.cursor);
 
         // highlight cursor
         int cursor = import_data.confirm.cursor;


### PR DESCRIPTION
Future work:

1. Improve scrollbar to better use the full space
2. Cache/lookahead the recording listings to remove small pause between pages. Potentially this could be unified with the existing snapshot caching.
3. Refactor and combine all the various memory card functionality between lab_css.c and lab.c