### PR TITLE
Fix savestate player colors on load

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1587,19 +1587,18 @@ int Savestate_Save(Savestate *savestate)
 
         FighterData *fighter_data = fighter->userdata;
 
-        // Aitch: temporarily remove savestate restrictions to find bugs
-        //if ((fighter_data->cb.OnDeath != 0) ||
-        //    (fighter_data->cb.OnDeath2 != 0) ||
-        //    (fighter_data->cb.OnDeath3 != 0) ||
-        //    (fighter_data->heldItem != 0) ||
-        //    (fighter_data->x1978 != 0) ||
-        //    (fighter_data->accessory != 0) ||
-        //    ((fighter_data->kind == 8) && ((fighter_data->state >= 342) && (fighter_data->state <= 344)))) // hardcode ness' usmash because it doesnt destroy the yoyo via onhit callback...
-        //{
-        //    // cannot save
-        //    canSave = 0;
-        //    break;
-        //}
+        if ((fighter_data->cb.OnDeath != 0) ||
+           (fighter_data->cb.OnDeath2 != 0) ||
+           (fighter_data->cb.OnDeath3 != 0) ||
+           (fighter_data->heldItem != 0) ||
+           (fighter_data->x1978 != 0) ||
+           (fighter_data->accessory != 0) ||
+           ((fighter_data->kind == 8) && ((fighter_data->state >= 342) && (fighter_data->state <= 344)))) // hardcode ness' usmash because it doesnt destroy the yoyo via onhit callback...
+        {
+           // cannot save
+           canSave = 0;
+           break;
+        }
 
         fighter = fighter->next;
     }

--- a/src/events.c
+++ b/src/events.c
@@ -1960,25 +1960,7 @@ int Savestate_Load(Savestate *savestate)
                     Fighter_ColorRemove(fighter_data, 9);
 
                     // restore color
-                    for (int k = 0; k < (sizeof(fighter_data->color) / sizeof(ColorOverlay)); k++)
-                    {
-
-                        ColorOverlay *thiscolor = &fighter_data->color[k];
-                        ColorOverlay *savedcolor = &ft_data->color[k];
-
-                        // backup nono pointers
-                        int *ptr1 = thiscolor->ptr1;
-                        int *ptr2 = thiscolor->ptr2;
-                        int *alloc = thiscolor->alloc;
-
-                        // mempcy entire
-                        memcpy(thiscolor, savedcolor, sizeof(ColorOverlay));
-
-                        // restore nono pointers
-                        thiscolor->ptr1 = ptr1;
-                        thiscolor->ptr2 = ptr2;
-                        thiscolor->alloc = alloc;
-                    }
+                    memcpy(fighter_data->color, ft_data->color, sizeof(fighter_data->color));
 
                     // restore smash variables
                     memcpy(&fighter_data->smash, &ft_data->smash, sizeof(fighter_data->smash)); // copy hitbox
@@ -2071,8 +2053,6 @@ int Savestate_Load(Savestate *savestate)
                     }
                 }
             }
-
-            sizeof(FtStateData);
 
             // check to recreate HUD
             MatchHUD *hud = &stc_matchhud[i];


### PR DESCRIPTION
Fixes #62. This removes the buggy behavior related to colors. I don't understand why UP wrote the original code the way he did. The 20XX hack pack's save state functionality also plainly copies the entire color section of the fighter data. I'm cautiously optimistic this won't introduce any crazy bugs, but I did play around with it for a while and it seemed fine.

I also restored the harmful save state detection you had commented out. I'm assuming you forgot to undo that.