### PR TITLE
Add "Up Smash" to "Counter Action (Shield)" as CPU Options of Training Lab

### DIFF
--- a/src/lab.h
+++ b/src/lab.h
@@ -1230,6 +1230,57 @@ static CPUAction Lab_CPUActionFSmash[] = {
     },
     -1,
 };
+static CPUAction Lab_CPUActionUpSmashOOS[] = {
+    {
+        ASID_GUARD,                   // state to perform this action. -1 for last
+        0,                            // first possible frame to perform this action
+        0,                            // last possible frame to perfrom this action
+        0,                            // left stick X value
+        0,                            // left stick Y value
+        0,                            // c stick X value
+        0,                            // c stick Y value
+        PAD_TRIGGER_R | PAD_BUTTON_X, // button to input
+        0,                            // is the last input
+        0,                            // specify stick direction
+    },
+    {
+        ASID_GUARD,   // state to perform this action. -1 for last
+        0,            // first possible frame to perform this action
+        0,            // last possible frame to perfrom this action
+        0,            // left stick X value
+        0,            // left stick Y value
+        0,            // c stick X value
+        0,            // c stick Y value
+        PAD_BUTTON_X, // button to input
+        0,            // is the last input
+        0,            // specify stick direction
+    },
+    {
+        ASID_KNEEBEND, // state to perform this action. -1 for last
+        0,             // first possible frame to perform this action
+        0,             // last possible frame to perfrom this action
+        0,             // left stick X value
+        0,             // left stick Y value
+        0,             // c stick X value
+        127,           // c stick Y value
+        0,             // button to input
+        1,             // is the last input
+        0,             // specify stick direction
+    },
+    {
+        ASID_ACTIONABLE, // state to perform this action. -1 for last
+        0,               // first possible frame to perform this action
+        0,               // last possible frame to perfrom this action
+        0,               // left stick X value
+        0,               // left stick Y value
+        0,               // c stick X value
+        127,             // c stick Y value
+        0,               // button to input
+        1,               // is the last input
+        0,               // specify stick direction
+    },
+    -1,
+};
 
 static CPUAction *Lab_CPUActions[] = {
     // none 0
@@ -1287,6 +1338,7 @@ static CPUAction *Lab_CPUActions[] = {
     &Lab_CPUActionUSmash,
     &Lab_CPUActionDSmash,
     &Lab_CPUActionFSmash,
+    &Lab_CPUActionUpSmashOOS,
 };
 enum CPU_ACTIONS
 {
@@ -1322,6 +1374,7 @@ enum CPU_ACTIONS
     CPUACT_USMASH,
     CPUACT_DSMASH,
     CPUACT_FSMASH,
+    CPUACT_USMASHOOS,
 };
 static char *CPU_ACTIONS_NAMES[] = {
     "CPUACT_NONE",
@@ -1356,10 +1409,11 @@ static char *CPU_ACTIONS_NAMES[] = {
     "CPUACT_USMASH",
     "CPUACT_DSMASH",
     "CPUACT_FSMASH",
+    "CPUACT_USMASHOOS",
 };
 static u8 GrAcLookup[] = {CPUACT_NONE, CPUACT_SPOTDODGE, CPUACT_SHIELD, CPUACT_GRAB, CPUACT_UPB, CPUACT_SIDEBTOWARD, CPUACT_SIDEBAWAY, CPUACT_DOWNB, CPUACT_NEUTRALB, CPUACT_USMASH, CPUACT_DSMASH, CPUACT_FSMASH, CPUACT_ROLLAWAY, CPUACT_ROLLTOWARDS, CPUACT_ROLLRDM, CPUACT_NAIR, CPUACT_FAIR, CPUACT_DAIR, CPUACT_BAIR, CPUACT_UAIR, CPUACT_JAB, CPUACT_FTILT, CPUACT_UTILT, CPUACT_DTILT, CPUACT_SHORTHOP, CPUACT_FULLHOP};
 static u8 AirAcLookup[] = {CPUACT_NONE, CPUACT_AIRDODGE, CPUACT_JUMPAWAY, CPUACT_JUMPTOWARDS, CPUACT_JUMPNEUTRAL, CPUACT_UPB, CPUACT_SIDEBTOWARD, CPUACT_SIDEBAWAY, CPUACT_DOWNB, CPUACT_NEUTRALB, CPUACT_NAIR, CPUACT_FAIR, CPUACT_DAIR, CPUACT_BAIR, CPUACT_UAIR, CPUACT_FFTUMBLE, CPUACT_FFWIGGLE};
-static u8 ShieldAcLookup[] = {CPUACT_NONE, CPUACT_GRAB, CPUACT_SHORTHOP, CPUACT_FULLHOP, CPUACT_SPOTDODGE, CPUACT_ROLLAWAY, CPUACT_ROLLTOWARDS, CPUACT_ROLLRDM, CPUACT_UPB, CPUACT_DOWNB, CPUACT_NAIR, CPUACT_FAIR, CPUACT_DAIR, CPUACT_BAIR, CPUACT_UAIR};
+static u8 ShieldAcLookup[] = {CPUACT_NONE, CPUACT_GRAB, CPUACT_SHORTHOP, CPUACT_FULLHOP, CPUACT_SPOTDODGE, CPUACT_ROLLAWAY, CPUACT_ROLLTOWARDS, CPUACT_ROLLRDM, CPUACT_USMASHOOS, CPUACT_UPB, CPUACT_DOWNB, CPUACT_NAIR, CPUACT_FAIR, CPUACT_DAIR, CPUACT_BAIR, CPUACT_UAIR};
 
 // MENUS ###################################################
 
@@ -1722,7 +1776,7 @@ static char **LabValues_Tech[] = {"Random", "Neutral", "Away", "Towards", "None"
 static char **LabValues_Getup[] = {"Random", "Stand", "Away", "Towards", "Attack"};
 static char **LabValues_CounterGround[] = {"None", "Spotdodge", "Shield", "Grab", "Up B", "Side B Toward", "Side B Away", "Down B", "Neutral B", "Up Smash", "Down Smash", "Forward Smash", "Roll Away", "Roll Towards", "Roll Random", "Neutral Air", "Forward Air", "Down Air", "Back Air", "Up Air", "Jab", "Forward Tilt", "Up Tilt", "Down Tilt", "Short Hop", "Full Hop"};
 static char **LabValues_CounterAir[] = {"None", "Airdodge", "Jump Away", "Jump Towards", "Jump Neutral", "Up B", "Side B Toward", "Side B Away", "Down B", "Neutral B", "Neutral Air", "Forward Air", "Down Air", "Back Air", "Up Air", "Tumble Fastfall", "Wiggle Fastfall"};
-static char **LabValues_CounterShield[] = {"None", "Grab", "Short Hop", "Full Hop", "Spotdodge", "Roll Away", "Roll Towards", "Roll Random", "Up B", "Down B", "Neutral Air", "Forward Air", "Down Air", "Back Air", "Up Air"};
+static char **LabValues_CounterShield[] = {"None", "Grab", "Short Hop", "Full Hop", "Spotdodge", "Roll Away", "Roll Towards", "Roll Random", "Up Smash", "Up B", "Down B", "Neutral Air", "Forward Air", "Down Air", "Back Air", "Up Air"};
 static char **LabValues_GrabEscape[] = {"None", "Medium", "High", "Perfect"};
 static char **LabValues_LockCPUPercent[] = {"Off", "On"};
 static EventOption LabOptions_CPU[] = {


### PR DESCRIPTION
Letting CPU up smash Out of shiled is possible for now in "Attack on Shield" but I want it with using "Counter After Frames/Shield Hits" on Training lab.
