### PR TITLE
Add GitHub Workflow that builds the ISO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build ISO
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker container
+      run: |
+        docker pull devkitpro/devkitppc
+
+    - name: Download iso from secret URL
+      run: |
+        curl -L ${{ secrets.GAME_ISO_URL }} -o game.iso
+
+    - name: Install Rust, GCC, and build gc_fst inside Docker
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          devkitpro/devkitppc \
+          bash -c "curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+                  apt-get update && \
+                  apt-get install -y gcc && \
+                  export PATH=\$HOME/.cargo/bin:\$PATH && \
+                  rm -rf gc_fst && \
+                  git clone https://github.com/AlexanderHarrison/gc_fst.git gc_fst_src && \
+                  cd gc_fst_src && cargo build --release && \
+                  cp target/release/gc_fst /workspace && \
+                  cd /workspace && rm -rf gc_fst_src"
+
+    - name: Install xdelta3 and mono, and build the ISO inside Docker
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/workspace \
+          -w /workspace \
+          devkitpro/devkitppc \
+          bash -c "apt-get update && apt-get install -y xdelta3 mono-complete && \
+                  PATH=$PATH:/usr/bin && \
+                  bash -c 'make iso=game.iso iso'"
+
+    - name: Upload ISO
+      uses: actions/upload-artifact@v4
+      with:
+        name: TM-More.iso
+        path: TM-More.iso

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build/Start.dol: | build
 	xdelta3 -d -f -s build/Start.dol "Build TM Start.dol/patch.xdelta" build/Start.dol
 
 TM-More.iso: build/Start.dol build/codes.gct $(dats)
-	if [[ ! -f TM-More.iso ]]; then cp ${iso} TM-More.iso; fi
+	if [ ! -f TM-More.iso ]; then cp ${iso} TM-More.iso; fi
 	./gc_fst fs TM-More.iso \
 		delete MvHowto.mth \
 		delete MvOmake15.mth \


### PR DESCRIPTION
Had to slightly change the Makefile to get it to work properly, due to `/bin/sh` not supporting double square brackets in if statements, and I couldn't seem to force Make to use bash. Let me know if this causes any regressions!

The `GAME_ISO_URL` GitHub secret is just a url that points to a Melee 1.02 ISO, I used one on my server that I can give the link to if need be