### PR TITLE
Fix rivival OSD asm to use Global.s

### DIFF
--- a/ASM/training-mode/Onscreen Display/Act OoJumpsquat.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJumpsquat.asm
@@ -1,60 +1,5 @@
     # To be inserted at 800cb698
-    .macro branchl reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    mtctr \reg
-    bctrl
-    .endm
-
-    .macro branch reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    mtctr \reg
-    bctr
-    .endm
-
-    .macro load reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    .endm
-
-    .macro loadf regf, reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    stw \reg, -0x4(sp)
-    lfs \regf, -0x4(sp)
-    .endm
-
-    .macro backup
-    mflr r0
-    stw r0, 0x4(r1)
-    stwu r1, -0x100(r1)             # make space for 12 registers
-    stmw r3, 0x8(r1)
-    .endm
-
-    .macro restore
-    lmw r3, 0x8(r1)
-    lwz r0, 0x104(r1)
-    addi r1, r1, 0x100              # release the space
-    mtlr r0
-    .endm
-
-    .macro intToFloat reg, reg2
-    xoris \reg, \reg, 0x8000
-    lis r18, 0x4330
-    lfd f16, -0x7470(rtoc)          # load magic number
-    stw r18, 0(r2)
-    stw \reg, 4(r2)
-    lfd \reg2, 0(r2)
-    fsubs \reg2, \reg2, f16
-    .endm
-
-    .set ActionStateChange, 0x800693ac
-    .set HSD_Randi, 0x80380580
-    .set HSD_Randf, 0x80380528
-    .set Wait, 0x8008a348
-    .set Fall, 0x800cc730
-    .set TextCreateFunction, 0x80005928
+    .include "../Globals.s"
 
     .set entity, 31
     .set playerdata, 31
@@ -77,23 +22,23 @@
     # Check For Not JumpSqaut
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0x18
-    beq Exit
+    beq Moonwalk_Exit
 
     # CHECK IF ENABLED
-    li r0, 0x13                     # PowerShield ID
+    li r0, OSD.ActOoJumpSquat                     # OSD Menu ID
     # lwz r4, -0xdbc(rtoc) #get frame data toggle bits
     lwz r4, -0x77C0(r13)
     lwz r4, 0x1F24(r4)
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Exit
+    beq Moonwalk_Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Exit
+    beq Moonwalk_Exit
 
     bl CreateText
 
@@ -129,7 +74,7 @@ StoreTextColor:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Exit
+    b Moonwalk_Exit
 
 CreateText:
     mflr r0
@@ -164,6 +109,6 @@ BottomText:
 
 ##############################
 
-Exit:
+Moonwalk_Exit:
     restore
     lwz r0, 0x0024(sp)

--- a/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
@@ -1,60 +1,5 @@
     # To be inserted at 800cb3a8
-    .macro branchl reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    mtctr \reg
-    bctrl
-    .endm
-
-    .macro branch reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    mtctr \reg
-    bctr
-    .endm
-
-    .macro load reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    .endm
-
-    .macro loadf regf, reg, address
-    lis \reg, \address @h
-    ori \reg, \reg, \address @l
-    stw \reg, -0x4(sp)
-    lfs \regf, -0x4(sp)
-    .endm
-
-    .macro backup
-    mflr r0
-    stw r0, 0x4(r1)
-    stwu r1, -0x100(r1)             # make space for 12 registers
-    stmw r3, 0x8(r1)
-    .endm
-
-    .macro restore
-    lmw r3, 0x8(r1)
-    lwz r0, 0x104(r1)
-    addi r1, r1, 0x100              # release the space
-    mtlr r0
-    .endm
-
-    .macro intToFloat reg, reg2
-    xoris \reg, \reg, 0x8000
-    lis r18, 0x4330
-    lfd f16, -0x7470(rtoc)          # load magic number
-    stw r18, 0(r2)
-    stw \reg, 4(r2)
-    lfd \reg2, 0(r2)
-    fsubs \reg2, \reg2, f16
-    .endm
-
-    .set ActionStateChange, 0x800693ac
-    .set HSD_Randi, 0x80380580
-    .set HSD_Randf, 0x80380528
-    .set Wait, 0x8008a348
-    .set Fall, 0x800cc730
-    .set TextCreateFunction, 0x80005928
+    .include "../Globals.s"
 
     .set entity, 31
     .set playerdata, 31
@@ -70,7 +15,7 @@
 ## Store Text Info here ##
 ##########################################################
 
-    backup
+    backupall
 
     mr player, r30
     lwz playerdata, 0x2c(player)
@@ -80,7 +25,7 @@
     beq Moonwalk_Exit
 
     # CHECK IF ENABLED
-    li r0, 0x12                     # PowerShield ID
+    li r0, OSD.ActOoJump                     # OSD Menu ID
     # lwz r4, -0xdbc(rtoc) #get frame data toggle bits
     lwz r4, -0x77C0(r13)
     lwz r4, 0x1F24(r4)
@@ -165,5 +110,5 @@ BottomText:
 ##############################
 
 Moonwalk_Exit:
-    restore
+    restoreall
     cmpwi r3, 0


### PR DESCRIPTION
I referenced [the commit](https://github.com/UnclePunch/Training-Mode/commit/f7aa10ed563dc710db75f060b619c2c734c2556e#diff-6eb9fc15ec595e8123cff2850fb1b39bee4216bb16222d3148d512bfbcc108a2) right before deleted of original `ASM/training-mode/Onscreen Display/Act OoJumpsquat.asm` and `ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm`
