### PR TITLE
Replace Moonwalk_Exit with Exit

### DIFF
--- a/ASM/Readme.md
+++ b/ASM/Readme.md
@@ -34,7 +34,6 @@ you're interested in learning more, you should read the Decomp Intro.
 
 - If you see a load with offset around 0x23ec-0x2424 in OSD related code,
   it's probably reading or writing to `struct MEX` or `struct TM` in `struct FighterData` in `MexTK/include/fighter.h`.
-- `Moonwalk_Exit` is not called that for any reason, it's just a generic exit.
 - **Don't be afraid of the dolphin debugger!**. Use the latest version of dolphin.
 - Everything in both `ASM/Globals.s` and `ASM/training-mode/Globals.s` are helper macros.
   These are imported into most other ASM files.

--- a/ASM/training-mode/Onscreen Display/Act OOS Frame Display/Display OOS Frame Count Standalone.asm
+++ b/ASM/training-mode/Onscreen Display/Act OOS Frame Display/Display OOS Frame Count Standalone.asm
@@ -36,22 +36,22 @@
     li r5, 1
     slw r0, r5, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForIASA:
     cmpwi r3, 0x1
-    bne Moonwalk_Exit
+    bne Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForGuardOff:
     lwz r3, 0x10(REG_FighterData)
     cmpwi r3, 0xB4
-    beq Moonwalk_Exit
+    beq Exit
 
 ShieldWaitCheck:
     # CHECK IF 3RD MOST RECENT AS WAS SHIELD STUN
@@ -64,7 +64,7 @@ GuardOffCheck:
     lhz r3, TM_ThreeASAgo(REG_FighterData)
     cmpwi r3, 0xB5
     beq CreateText
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     # Change color to Green if frame perfect act oos
@@ -88,7 +88,7 @@ PrintMessage:
     addi r7, r7, 1
     Message_Display
 
-    b Moonwalk_Exit
+    b Exit
 
     /*
     mr r3, REG_FighterData                      # backup REG_FighterData pointer
@@ -129,7 +129,7 @@ NotFramePerfect:
     lfs f2, -0x37B0(rtoc)                       # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
     */
 
 ###################
@@ -143,6 +143,6 @@ OoS_String:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     blr

--- a/ASM/training-mode/Onscreen Display/Act OOTumble/Static Function - Display Frames Spent Post Hitstun.asm
+++ b/ASM/training-mode/Onscreen Display/Act OOTumble/Static Function - Display Frames Spent Post Hitstun.asm
@@ -23,7 +23,7 @@
 
     # Check For Interrupt
     cmpwi r3, 0x1
-    bne Moonwalk_Exit
+    bne Exit
 
     # CHECK IF ENABLED
     li r0, OSD.ActOoHitstun         # PowerShield ID
@@ -33,13 +33,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check if frame 1
     lhz r3, TM_PostHitstunFrameCount(REG_FighterData)
@@ -64,7 +64,7 @@ PrintMessage:
     addi r7, r7, 1
     Message_Display
 
-    b Moonwalk_Exit
+    b Exit
 
     /*
     bl CreateText
@@ -129,6 +129,6 @@ ActOoHitstun_String:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restore
     blr

--- a/ASM/training-mode/Onscreen Display/Act OoJumpsquat.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoJumpsquat.asm
@@ -22,7 +22,7 @@
     # Check For Not JumpSqaut
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0x18
-    beq Moonwalk_Exit
+    beq Exit
 
     # CHECK IF ENABLED
     li r0, OSD.ActOoJumpSquat                     # OSD Menu ID
@@ -32,13 +32,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     bl CreateText
 
@@ -74,7 +74,7 @@ StoreTextColor:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -109,6 +109,6 @@ BottomText:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restore
     lwz r0, 0x0024(sp)

--- a/ASM/training-mode/Onscreen Display/Act OoWait/Act OOWait- Standalone.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoWait/Act OOWait- Standalone.asm
@@ -31,13 +31,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Calculate Frames Since Wait and Get AS Before Wait
     li r5, 0                                    # Loop Count
@@ -51,7 +51,7 @@ WaitSearchLoop:
     beq WaitSearchExit
     addi r5, r5, 1
     cmpwi r5, 6
-    bge Moonwalk_Exit
+    bge Exit
     b WaitSearchLoop
 
 WaitSearchExit:
@@ -80,7 +80,7 @@ FrameCountLoopFinish:
 
     # Check If Under 13 Frames
     cmpwi FramesSince, 13
-    bgt Moonwalk_Exit
+    bgt Exit
 
     # Only Coming from Throws, Aerial Landing, and Teching/Getups
     # Aerial Landing
@@ -114,7 +114,7 @@ NotTeching:
     b ComingFromWhitelist
 
 NotWavedash:
-    b Moonwalk_Exit
+    b Exit
 
 ComingFromWhitelist:
 SpawnText:
@@ -148,7 +148,7 @@ ChangeColor:
     addi r5, sp, 0x80
     branchl r12, Text_ChangeTextColor
 
-    b Moonwalk_Exit
+    b Exit
 
 ###################
 ## TEXT CONTENTS ##
@@ -161,6 +161,6 @@ TechText:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     blr

--- a/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Crouch.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Crouch.asm
@@ -24,22 +24,22 @@
     # Check If Interrupted
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0x27
-    beq Moonwalk_Exit
+    beq Exit
 
     # Make Sure Player Didn't Buffer Shield
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0xB2
-    beq Moonwalk_Exit
+    beq Exit
 
     # Ensure I'm Actually Coming from Wait
     lhz r3, TM_TwoASAgo(playerdata)
     cmpwi r3, 0xE
-    bne Moonwalk_Exit
+    bne Exit
 
     # Check To Display OSD
     mr r3, r31
     branchl r12, 0x8000551c
 
-Moonwalk_Exit:
+Exit:
     restoreall
     lwz r0, 0x0024(sp)

--- a/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Landing.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Landing.asm
@@ -20,7 +20,7 @@
 
     # Check if Interrupted
     cmpwi r3, 0x1
-    bne Moonwalk_Exit
+    bne Exit
 
     # CHECK IF ENABLED
     li r0, 0x10                                 # PowerShield ID
@@ -30,33 +30,33 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Ensure I'm Actually Coming from Landing (Wait interrupt is used for certain IASA)
     lhz r3, TM_OneASAgo(playerdata)
     cmpwi r3, ASID_Landing
-    bne Moonwalk_Exit
+    bne Exit
 
     # Make Sure Player Didn't Buffer Crouch, Shield, or Walk
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0xF
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x10
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x11
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x27
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0xB2
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, ASID_SquatWait
-    beq Moonwalk_Exit
+    beq Exit
 
 # Ensure player came from aerial attack landing or special move
 CheckForAerial:
@@ -69,7 +69,7 @@ CheckForAerial:
 
 CheckForSpecialMove:
     cmpwi r3, ASID_BarrelCannonWait
-    ble Moonwalk_Exit
+    ble Exit
 
 LandingSearch:
     # Calculate Frames Since Wait and Get AS Before Wait
@@ -84,7 +84,7 @@ LandingSearchLoop:
     beq LandingSearchExit
     addi r5, r5, 1
     cmpwi r5, 6
-    bge Moonwalk_Exit
+    bge Exit
     b LandingSearchLoop
 
 LandingSearchExit:
@@ -147,7 +147,7 @@ ChangeColor:
     addi r5, sp, 0x80
     branchl r12, Text_ChangeTextColor
 
-    b Moonwalk_Exit
+    b Exit
 
 ###################
 ## TEXT CONTENTS ##
@@ -160,6 +160,6 @@ Text:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     lwz r0, 0x002C(sp)

--- a/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Wait.asm
+++ b/ASM/training-mode/Onscreen Display/Act OoWait/Act OoWait - From Wait.asm
@@ -20,7 +20,7 @@
 
     # Check If Interrupted
     cmpwi r3, 0x0
-    beq Moonwalk_Exit
+    beq Exit
 
     # Get Playerdata
     lwz playerdata, 0x2C(player)
@@ -28,27 +28,27 @@
     # Ensure I'm Actually Coming from Wait (Wait interrupt is used for certain IASA)
     lhz r3, TM_OneASAgo(playerdata)
     cmpwi r3, 0xE
-    bne Moonwalk_Exit
+    bne Exit
 
     # Make Sure Player Didn't Buffer Crouch, Shield, or Walk
     lwz r3, 0x10(playerdata)
     cmpwi r3, 0xF
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x10
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x11
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x27
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0xB2
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, ASID_SquatWait
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check To Display OSD
     mr r3, r31
     branchl r12, 0x8000551c
 
-Moonwalk_Exit:
+Exit:
     restoreall
     lwz r0, 0x001C(sp)

--- a/ASM/training-mode/Onscreen Display/Additional Playerblock Variables/Fastfall Timer/Display FF Timing.asm
+++ b/ASM/training-mode/Onscreen Display/Additional Playerblock Variables/Fastfall Timer/Display FF Timing.asm
@@ -27,20 +27,20 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check If Falling Off Ledge and Respawn Platform
     lhz r3, TM_OneASAgo(REG_FighterData)
     # cmpwi r3, 0xFD #CliffWait
-    # beq Moonwalk_Exit
+    # beq Exit
     cmpwi r3, 0xD                   # RebirthWait
-    beq Moonwalk_Exit
+    beq Exit
 
 PrintMessage:
     li r3, 7                        # Message Kind
@@ -56,14 +56,14 @@ PrintMessage:
     # Check if frame 1
     lhz r3, TM_CanFastfallFrameCount(REG_FighterData)
     cmpwi r3, 1
-    bne Moonwalk_Exit
+    bne Exit
     mr r3, REG_Text
     li r4, 1
     bl Colors
     mflr r5
     branchl r12, Text_ChangeTextColor
 
-    b Moonwalk_Exit
+    b Exit
 
 ###################
 ## TEXT CONTENTS ##
@@ -80,6 +80,6 @@ Colors:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     li r0, 1

--- a/ASM/training-mode/Onscreen Display/Additional Playerblock Variables/Frame Advantage/Initialize Frame Advantage Think.asm
+++ b/ASM/training-mode/Onscreen Display/Additional Playerblock Variables/Frame Advantage/Initialize Frame Advantage Think.asm
@@ -76,7 +76,7 @@ SkipGrabCheck:
 # Check If ShieldStun Ended
 # lwz r3, 0x10(REG_VictimData)
 # cmpwi r3, 0xB5
-# beq Moonwalk_Exit
+# beq Exit
 
 #########################
 ## Check If Actionable ##
@@ -134,7 +134,7 @@ SkipAttackCheck:
     b CheckIASA
 
 SkipThrowCheck:
-    b Moonwalk_Exit
+    b Exit
 
 #########################
 ## Check for IASA Flag ##
@@ -143,7 +143,7 @@ SkipThrowCheck:
 CheckIASA:
     lbz r3, 0x2218(REG_FighterData)
     rlwinm. r3, r3, 0, 24, 24
-    beq Moonwalk_Exit
+    beq Exit
 
 ##########################
 ## Get Frame Advantages ##
@@ -269,7 +269,7 @@ SelfDestruct:
     stw r3, TM_AnimCallback(REG_FighterData)
 
     # Exit
-    b Moonwalk_Exit
+    b Exit
 
 ###################
 ## TEXT CONTENTS ##
@@ -282,7 +282,7 @@ FrameAdvantage_String:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restore
     blr
 

--- a/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
@@ -22,7 +22,7 @@
 
     # Check For Interrupt
     cmpwi r3, 0x0
-    beq Moonwalk_Exit
+    beq Exit
 
     # CHECK IF ENABLED
     li r0, OSD.ActOoJump                     # OSD Menu ID
@@ -32,13 +32,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     bl CreateText
 
@@ -74,7 +74,7 @@ StoreTextColor:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -109,6 +109,6 @@ BottomText:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
+++ b/ASM/training-mode/Onscreen Display/Aerial Out of Jump.asm
@@ -15,7 +15,7 @@
 ## Store Text Info here ##
 ##########################################################
 
-    backupall
+    backup
 
     mr player, r30
     lwz playerdata, 0x2c(player)
@@ -110,5 +110,5 @@ BottomText:
 ##############################
 
 Exit:
-    restoreall
+    restore
     cmpwi r3, 0

--- a/ASM/training-mode/Onscreen Display/Check For ICs Static Function.asm
+++ b/ASM/training-mode/Onscreen Display/Check For ICs Static Function.asm
@@ -91,6 +91,6 @@ Follower:
 NoFollower:
     li r3, 0x0
 
-Moonwalk_Exit:
+Exit:
     restore
     blr

--- a/ASM/training-mode/Onscreen Display/Combo Counter/Combo Counter - On Combo Increment.asm
+++ b/ASM/training-mode/Onscreen Display/Combo Counter/Combo Counter - On Combo Increment.asm
@@ -32,7 +32,7 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
     # Get Playerdata
     mr r3, r27
@@ -44,11 +44,11 @@ CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check If Combo Count is 2 Hits or Higher
     cmpwi ComboCount, 2
-    blt Moonwalk_Exit
+    blt Exit
 
     bl CreateText
 
@@ -79,7 +79,7 @@ CheckForFollower:
     # Check If Valid Player GObj
     branchl r12, 0x80086960
     cmpwi r3, 0
-    beq Moonwalk_Exit
+    beq Exit
     # Store Function
     bl HitstunMonitor
     mflr r3
@@ -87,7 +87,7 @@ CheckForFollower:
     lwz r4, 0x2C(r4)
     stw r3, TM_AnimCallback(r4)
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -246,6 +246,6 @@ HitstunMonitor_Exit:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restore
     lmw r27, 0x0024(sp)

--- a/ASM/training-mode/Onscreen Display/Dashback/Dashback Display - Static Function.asm
+++ b/ASM/training-mode/Onscreen Display/Dashback/Dashback Display - Static Function.asm
@@ -32,13 +32,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Change color to Green if frame perfect act oos
     cmpwi REG_DBBool, 0x0
@@ -110,7 +110,7 @@ ChangeColor:
     li r4, 0
     branchl r12, Text_ChangeTextColor
 
-    b Moonwalk_Exit
+    b Exit
 
 #########################
 ### DB Rate Functions ###
@@ -214,6 +214,6 @@ Colors:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     blr

--- a/ASM/training-mode/Onscreen Display/Dashback/Run Out of Tilt Turn.asm
+++ b/ASM/training-mode/Onscreen Display/Dashback/Run Out of Tilt Turn.asm
@@ -21,9 +21,9 @@
     # Ensure NOT Coming From Dash or Crouch
     lhz r3, TM_OneASAgo(playerdata) # load last AS
     cmpwi r3, 0x14
-    beq Moonwalk_Exit
+    beq Exit
     cmpwi r3, 0x28
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check If Dashed Back (Flag at 0x2340)
     mr r3, player
@@ -35,7 +35,7 @@
     li r4, 0x1
     branchl r12, 0x80005518
 
-Moonwalk_Exit:
+Exit:
     restoreall
     mr r3, r30
     li r4, 0x0

--- a/ASM/training-mode/Onscreen Display/Fox Training Codes/Side B Shorten Display.asm
+++ b/ASM/training-mode/Onscreen Display/Fox Training Codes/Side B Shorten Display.asm
@@ -28,7 +28,7 @@
     beq FoxFalco
 
     # Check If Anyone Else
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -41,7 +41,7 @@ FoxFalco:
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
     # Branch to AS Functions
     lwz r3, 0x10(playerdata)
@@ -65,7 +65,7 @@ FoxFalco:
     cmpwi r3, 0x16E
     beq Fox_ShineAirLoop
 
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -110,7 +110,7 @@ Fox_SideBStart:
     branchl r12, 0x803a6b98
 
 Fox_SideBStart_NoPress:
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -148,7 +148,7 @@ Fox_SideB:
     branchl r12, 0x803a6b98
 
 Fox_SideB_NoPress:
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -186,7 +186,7 @@ Fox_SideBEnd:
     branchl r12, 0x803a6b98
 
 Fox_SideBEnd_NoPress:
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -194,7 +194,7 @@ Fox_ShineGroundLoop:
     # Check For JC
     bl CheckForJumpCancel
     cmpwi r3, 0x0
-    beq Moonwalk_Exit
+    beq Exit
 
 Fox_ShineGroundLoop_Interrupted:
     # Create Text
@@ -245,7 +245,7 @@ Fox_ShineGroundLoop_BottomLine:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -254,12 +254,12 @@ Fox_ShineAirLoop:
     lbz r3, 0x1968(playerdata)      # Jumps Used
     lwz r0, 0x0168(playerdata)      # Total Jumps
     cmpw r3, r0
-    bge Moonwalk_Exit
+    bge Exit
 
     # Check For JC
     bl CheckForJumpCancel
     cmpwi r3, 0x0
-    beq Moonwalk_Exit
+    beq Exit
 
 Fox_ShineAirLoop_Interrupted:
     # Create Text
@@ -310,7 +310,7 @@ Fox_ShineAirLoop_BottomLine:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 # /////////////////////////////////////////////////////////////////////////////
 
@@ -411,6 +411,6 @@ ActOOShineBottom:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     lwz r12, 0x219C(r31)

--- a/ASM/training-mode/Onscreen Display/L Cancel Display NEW.asm
+++ b/ASM/training-mode/Onscreen Display/L Cancel Display NEW.asm
@@ -28,13 +28,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check if succeeded
     lbz r5, 0x67F(REG_FighterData)  # get decimal to print
@@ -85,7 +85,7 @@ PrintMessage:
     mflr r5
     branchl r12, Text_ChangeTextColor
 
-    b Moonwalk_Exit
+    b Exit
 
 #########################
 ### LC Rate Functions ###
@@ -178,7 +178,7 @@ Color_White:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
 
     lwz r0, 0x0034(sp)

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/Frames Spent in CliffWait.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/Frames Spent in CliffWait.asm
@@ -30,18 +30,18 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check if Over 20 Frames
     lhz r3, 0x23f8(playerdata)
     cmpwi r3, 20
-    bgt Moonwalk_Exit
+    bgt Exit
 
     bl CreateText
 
@@ -79,7 +79,7 @@ StoreTextColor:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -112,5 +112,5 @@ BottomText:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Aerail Interrupt.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Aerail Interrupt.asm
@@ -21,11 +21,11 @@
     # Check For CliffWait
     lhz r4, TM_ThreeASAgo (r5)
     cmpwi r4, 0xFD
-    bne Moonwalk_Exit
+    bne Exit
 
     li r4, 1
     branchl r12, 0x80005514
 
-Moonwalk_Exit:
+Exit:
     restoreall
     branchl r12, 0x800d5bf8

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Laser Land.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Laser Land.asm
@@ -31,7 +31,7 @@ CliffWaitSearch:
     addi r5, r5, 1
     cmpwi r5, 5
     ble CliffWaitSearch
-    b Moonwalk_Exit
+    b Exit
 
 # Display GALINT
 DisplayGALINT:
@@ -39,6 +39,6 @@ DisplayGALINT:
     li r4, 0
     branchl r12, 0x80005514
 
-Moonwalk_Exit:
+Exit:
     restoreall
     mr r3, r28

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Ledgedash.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT Ledgedash.asm
@@ -23,16 +23,16 @@
     # Check If Coming From Airdodge
     lhz r3, TM_OneASAgo (r5)
     cmpwi r3, 0xEC
-    bne Moonwalk_Exit
+    bne Exit
     # Check For CliffWait
     lhz r3, TM_FourASAgo (r5)
     cmpwi r3, 0xFD
-    bne Moonwalk_Exit
+    bne Exit
 
     mr r3, r31
     li r4, 0
     branchl r12, 0x80005514
 
-Moonwalk_Exit:
+Exit:
     restoreall
     mr r3, r31

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT No Impact Land.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/GALINT No Impact Land.asm
@@ -23,12 +23,12 @@
     # Check For CliffWait
     lhz r3, TM_TwoASAgo (r5)
     cmpwi r3, 0xFD
-    bne Moonwalk_Exit
+    bne Exit
 
     mr r3, r30
     li r4, 0
     branchl r12, 0x80005514
 
-Moonwalk_Exit:
+Exit:
     restoreall
     mr r3, r30

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/Standalaone - GALINT Display.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/GALINT/Standalaone - GALINT Display.asm
@@ -30,18 +30,18 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check if Over 20 Frames past GALINT
     lhz r3, TM_TangibleFrameCount(playerdata)
     cmpwi r3, 20
-    bgt Moonwalk_Exit
+    bgt Exit
 
     # Get GALINT Frames (Ledge Intang - Landing Lag)
     lwz REG_GALINT, 0x1990(playerdata)
@@ -96,7 +96,7 @@ SkipShowingTangibleFrames:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -129,6 +129,6 @@ BottomText:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     blr

--- a/ASM/training-mode/Onscreen Display/Ledge Codes/Ledgestall/Ledgestall Display.asm
+++ b/ASM/training-mode/Onscreen Display/Ledge Codes/Ledgestall/Ledgestall Display.asm
@@ -28,19 +28,19 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, playerdata
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
     # Check If Under 15 Frames
     lhz r3, 0x2416(playerdata)
     subi r3, r3, 1
     cmpwi r3, 15
-    bgt Moonwalk_Exit
+    bgt Exit
 
     bl CreateText
 
@@ -86,7 +86,7 @@ LateLedgestall:
     lfs f2, -0x37B0(rtoc)           # shift down on Y axis
     branchl r12, 0x803a6b98
 
-    b Moonwalk_Exit
+    b Exit
 
 CreateText:
     mflr r0
@@ -124,6 +124,6 @@ BottomText_PerfectStall:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     restoreall
     lwz r0, 0x0034(sp)

--- a/ASM/training-mode/Onscreen Display/Message Display System/Display Message 2.0.asm
+++ b/ASM/training-mode/Onscreen Display/Message Display System/Display Message 2.0.asm
@@ -210,7 +210,7 @@ GetYLocation:
     lfs f2, 0x18(textprop)      # stretch Y (30)
     branchl r12, 0x803a7548
 
-    b Moonwalk_Exit
+    b Exit
 
 #######################################################################
 
@@ -421,7 +421,7 @@ TextASCII3:
     blrl
     .long 0x815B0000
 
-Moonwalk_Exit:
+Exit:
     mr r3, text                 # return text pointer
     restore
     blr

--- a/ASM/training-mode/Onscreen Display/SDI Display/SDI Display Main.asm
+++ b/ASM/training-mode/Onscreen Display/SDI Display/SDI Display Main.asm
@@ -29,13 +29,13 @@
     li r3, 1
     slw r0, r3, r0
     and. r0, r0, r4
-    beq Moonwalk_Exit
+    beq Exit
 
 CheckForFollower:
     mr r3, REG_FighterData
     branchl r12, 0x80005510
     cmpwi r3, 0x1
-    beq Moonwalk_Exit
+    beq Exit
 
 SDICheck:
     # Check For SDI
@@ -88,7 +88,7 @@ PrintMessage:
     lhz r8, TM_TotalSDIInputs(REG_FighterData)
     Message_Display
 
-    b Moonwalk_Exit
+    b Exit
 
 ###################
 ## TEXT CONTENTS ##
@@ -108,7 +108,7 @@ Floats:
 
 ##############################
 
-Moonwalk_Exit:
+Exit:
     lfs f0, 0x80(sp)
     lfs f1, 0x84(sp)
     lfs f2, 0x8C(sp)


### PR DESCRIPTION
I made sure none of the affected files had both `Moonwalk_Exit` _and_ `Exit` labels. This is just to reduce any confusion that might arise.