### PR TITLE
Touchups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ dats = build/ledgedash.dat build/wavedash.dat build/lcancel.dat build/labCSS.dat
 ASM_FILES := $(shell find ASM -type f \( -name '*.asm' -o -name '*.s' \) | sed 's/ /\\ /g')
 
 MEX_BUILD=mono MexTK/MexTK.exe -ff -b "build" -q -ow -l "MexTK/melee.link" -op 2
-MEX_TRIM=mono MexTK/MexTK.exe -trim
 
 clean:
 	rm -rf TM-More.iso
@@ -15,32 +14,26 @@ clean:
 build/eventMenu.dat: src/events.c src/events.h
 	cp "dats/eventMenu.dat" "build/eventMenu.dat" 
 	$(MEX_BUILD) -i "src/events.c" -s "tmFunction" -dat "build/eventMenu.dat" -t "MexTK/tmFunction.txt"
-	$(MEX_TRIM) "build/eventMenu.dat"
 
 build/lab.dat: src/lab.c src/lab.h src/lab_common.h
 	cp "dats/lab.dat" "build/lab.dat"
 	$(MEX_BUILD) -i "src/lab.c" -s "evFunction" -dat "build/lab.dat" -t "MexTK/evFunction.txt"
-	$(MEX_TRIM) "build/lab.dat"
 
 build/labCSS.dat: src/lab_css.c src/lab_common.h
 	cp "dats/labCSS.dat" "build/labCSS.dat"
 	$(MEX_BUILD) -i "src/lab_css.c" -s "cssFunction" -dat "build/labCSS.dat" -t "MexTK/cssFunction.txt"
-	$(MEX_TRIM) "build/labCSS.dat"
 
 build/lcancel.dat: src/lcancel.c src/lcancel.h
 	cp "dats/lcancel.dat" "build/lcancel.dat"
 	$(MEX_BUILD) -i "src/lcancel.c" -s "evFunction" -dat "build/lcancel.dat" -t "MexTK/evFunction.txt"
-	$(MEX_TRIM) "build/lcancel.dat"
 
 build/ledgedash.dat: src/ledgedash.c src/ledgedash.h
 	cp "dats/ledgedash.dat" "build/ledgedash.dat"
 	$(MEX_BUILD) -i "src/ledgedash.c" -s "evFunction" -dat "build/ledgedash.dat" -t "MexTK/evFunction.txt"
-	$(MEX_TRIM) "build/ledgedash.dat"
 
 build/wavedash.dat: src/wavedash.c src/wavedash.h
 	cp "dats/wavedash.dat" "build/wavedash.dat"
 	$(MEX_BUILD) -i "src/wavedash.c" -s "evFunction" -dat "build/wavedash.dat" -t "MexTK/evFunction.txt"
-	$(MEX_TRIM) "build/wavedash.dat"
 
 build/codes.gct: Additional\ ISO\ Files/opening.bnr $(ASM_FILES)
 	cd "Build TM Codeset" && ./gecko build

--- a/MexTK/include/mex.h
+++ b/MexTK/include/mex.h
@@ -289,8 +289,6 @@ void bp();
 PRIM *PRIM_NEW(int vert_count, int params1, int params2);
 void PRIM_CLOSE();
 MEXPlaylist *MEX_GetPlaylist();
-// void KirbyStateChange(GOBJ *fighter, int state, float startFrame, float animSpeed, float animBlend);
-void KirbyStateChange(float anim_start_frame, float anim_rate, float anim_blend, GOBJ *f, int state_id, int flags, GOBJ *alt_state_source);
 void *MEX_GetKirbyCpData(int copy_id);
 void *MEX_GetData(int index);
 

--- a/MexTK/melee.link
+++ b/MexTK/melee.link
@@ -720,7 +720,6 @@
 8016895C:JOBJ_AddSetAnim
 8000B804:JOBJ_ResetFromDesc
 8036F4C8:JOBJ_RemoveAnimByFlags
-803D7080:KirbyStateChange
 802F2810:AS_CaptureWaitKirbyItem
 800BD620:AS_CaptureWaitKirby
 800F190C:Kirby_ResetCopyCharVars

--- a/src/events.c
+++ b/src/events.c
@@ -1053,7 +1053,6 @@ static EventVars stc_event_vars = {
 };
 static Savestate *stc_savestate;
 static EventDesc *static_eventInfo;
-static MenuData *static_menuData;
 static int show_console = 1;
 static int *eventDataBackup;
 static TipMgr stc_tipmgr;

--- a/src/events.h
+++ b/src/events.h
@@ -381,7 +381,6 @@ void Event_IncTimer(GOBJ *gobj);
 void Test_Think(GOBJ *gobj);
 void Hazards_Disable();
 static EventDesc *static_eventInfo;
-static MenuData *static_menuData;
 static EventVars stc_event_vars;
 static int *eventDataBackup;
 


### PR DESCRIPTION
Few small touchups. Kirby function has same address as `Mex_LoadRelArchive`, so I removed it even though it wasn't causing issues. There's a few unused `Mex_*` functions we could remove, but I will leave them for now.