### PR TITLE
Add Timer Options to Amsah-Tech Training

### DIFF
--- a/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
+++ b/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
@@ -4613,38 +4613,37 @@ AmsahTechWindowText:
 ## Up B Timer Frame Option ##
 #############################
 
-    # Window Title = Up B Timer Frame
-    .long 0x55702042
-    .long 0x2054696d
-    .long 0x65722046
-    .long 0x72616d65
-    .long 0x00000000
+    # Window Title
+    .string "Up B Timer Frame"
+    .align 2
 
-    # Option 1 = 30
-    .long 0x33300000
+    # Option 1
+    .string "30"
+    .align 2
 
-    # Option 2 = 50
-    .long 0x35300000
+    # Option 2
+    .string "50"
+    .align 2
 
 #############################
 ## Reset Timer Frame Option ##
 #############################
 
-    # Window Title = Reset Timer Frame
-    .long 0x52657365
-    .long 0x74205469
-    .long 0x6d657220
-    .long 0x4672616d
-    .long 0x65000000
+    # Window Title
+    .string "Reset Timer Frame"
+    .align 2
 
-    # Option 1 = 120
-    .long 0x31323000
+    # Option 1
+    .string "120"
+    .align 2
 
-    # Option 2 = 180
-    .long 0x31383000
+    # Option 2
+    .string "180"
+    .align 2
 
-    # Option 3 = 240
-    .long 0x32343000
+    # Option 3
+    .string "240"
+    .align 2
 
 AmsahTechLoadExit:
     restore

--- a/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
+++ b/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
@@ -4312,8 +4312,10 @@ AmsahTechLoad:
 
     # Offsets
     .set Timer, 0x8
-    .set TimerOption, MenuData_OptionMenuMemory+0x2 + 0x0
-    .set TimerOptionToggled, MenuData_OptionMenuToggled + 0x0
+    .set UpBTimerOption, MenuData_OptionMenuMemory+0x2 + 0x0
+    .set ResetTimerOption, MenuData_OptionMenuMemory+0x2 + 0x1
+    .set UpBTimerOptionToggled, MenuData_OptionMenuToggled + 0x0
+    .set ResetTimerOptionToggled, MenuData_OptionMenuToggled + 0x1
 
 AmsahTechThink:
     blrl
@@ -4459,7 +4461,7 @@ AmsahTechIsTaunting:
     branchl r12, Air_SetAsGrounded
 
 AmsahTechSetUpBTimer:
-    lbz r3, TimerOption(MenuData)
+    lbz r3, UpBTimerOption(MenuData)
     cmpwi r3, 0x0
     beq AmsahTechSetUpBTimer_30
     cmpwi r3, 0x1
@@ -4535,11 +4537,31 @@ AmsahTechCheckUpBTimer:
     stw r3, 0x1A88(r29)
     li r3, 127
     stb r3, 0x1A8D(r29)
-    # Initiate Reset Timer
+
+AmsahTechInitiateResetTimer:
+    lbz r3, ResetTimerOption(MenuData)
+    cmpwi r3, 0x0
+    beq AmsahTechResetTimer_120
+    cmpwi r3, 0x1
+    beq AmsahTechResetTimer_180
+    cmpwi r3, 0x2
+    beq AmsahTechResetTimer_240
+
+AmsahTechResetTimer_120:
     li r3, 120
     stw r3, 0x4(r31)
+    b AmsahTechCheckToReset
 
-# Check To Reset
+AmsahTechResetTimer_180:
+    li r3, 180
+    stw r3, 0x4(r31)
+    b AmsahTechCheckToReset
+
+AmsahTechResetTimer_240:
+    li r3, 240
+    stw r3, 0x4(r31)
+    b AmsahTechCheckToReset
+
 AmsahTechCheckToReset:
     lwz r3, 0x4(r31)                                    # get timer #Get Timer
     cmpwi r3, 0x0                                       # No Reset Timer Set Yet
@@ -4580,7 +4602,7 @@ AmsahTech_Floats:
 AmsahTechWindowInfo:
     blrl
     # amount of options, amount of options in each window
-    .long 0x00010000                                    # 1 window, 2 options
+    .long 0x01010200                                    # 2 window, Up B Timer has 2 options, Reset Timer has 3 options
 
 ####################################################
 
@@ -4603,6 +4625,26 @@ AmsahTechWindowText:
 
     # Option 2 = 50
     .long 0x35300000
+
+#############################
+## Reset Timer Frame Option ##
+#############################
+
+    # Window Title = Reset Timer Frame
+    .long 0x52657365
+    .long 0x74205469
+    .long 0x6d657220
+    .long 0x4672616d
+    .long 0x65000000
+
+    # Option 1 = 120
+    .long 0x31323000
+
+    # Option 2 = 180
+    .long 0x31383000
+
+    # Option 3 = 240
+    .long 0x32343000
 
 AmsahTechLoadExit:
     restore


### PR DESCRIPTION
## Adjustable Up B Timer (conventionally 30 Frame)
- I think 30 frame is too fast for beginners of this technique or users of B0XX style controller which has bothering input to taunt
- so I want to make it adjustable 30 or 50 on Pause option
- (60+ frame make player be able to shield before Up B. I thought adding other longer frames is interesting for training punishment with celing glitch but stop it because it seems to bring necessary to fix other places beyond my skill)

## Adjustable Reset Timer (conventionally 120 Frame)
- 120 is good for almost characters
- but for some low-friction characters (e.g. ICs, Luigi), it was too short to withstand on the ledge until knockbak speed runs out by using spot-dodge in a row
  - e.g. Luigi needs to spot dodge 8 times. For this 240 Frame is good
    https://youtu.be/JuXA_wRzARw
    
    