### PR TITLE
EventMatchData cleanups

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -28,9 +28,6 @@ static EventMatchData Lab_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
     .timerSeconds = 0,
 };
 EventDesc Lab = {
@@ -42,14 +39,15 @@ EventDesc Lab = {
     .eventCSSFile = "TM/labCSS.dat",
     .CSSType = SLCHRKIND_TRAINING,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
     .matchData = &Lab_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
 };
 
 // L-Cancel Training
@@ -66,9 +64,6 @@ static EventMatchData LCancel_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
     .timerSeconds = 0,
 };
 EventDesc LCancel = {
@@ -79,14 +74,15 @@ EventDesc LCancel = {
     .jumpTableIndex = -1,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 15,
     .matchData = &LCancel_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
 };
 
 // Ledgedash Training
@@ -103,9 +99,6 @@ static EventMatchData Ledgedash_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
     .timerSeconds = 0,
 };
 EventDesc Ledgedash = {
@@ -115,14 +108,15 @@ EventDesc Ledgedash = {
     .jumpTableIndex = -1,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = true,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 15,
     .matchData = &Ledgedash_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
 };
 
 // Wavedash Training
@@ -139,9 +133,6 @@ static EventMatchData Wavedash_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
     .timerSeconds = 0,
 };
 EventDesc Wavedash = {
@@ -151,35 +142,18 @@ EventDesc Wavedash = {
     .jumpTableIndex = -1,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 15,
     .matchData = &Wavedash_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
 };
 
 // Combo Training
-static EventMatchData Combo_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc Combo = {
 
     .eventName = "Combo Training\n",
@@ -188,35 +162,18 @@ EventDesc Combo = {
     .jumpTableIndex = JUMP_COMBO,
     .CSSType = SLCHRKIND_TRAINING,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Combo_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
 // Attack On Shield Training
-static EventMatchData AttackOnShield_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
-};
 EventDesc AttackOnShield = {
     .eventName = "Attack on Shield\n",
     .eventDescription = "Practice attacks on a shielding opponent\nPause to change their OoS option.\n",
@@ -224,35 +181,17 @@ EventDesc AttackOnShield = {
     .jumpTableIndex = JUMP_ATTACKONSHIELD,
     .CSSType = SLCHRKIND_TRAINING,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &AttackOnShield_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-// Reversal Training
-static EventMatchData Reversal_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc Reversal = {
     .eventName = "Reversal Training\n",
     .eventDescription = "Practice OoS punishes! DPad left/right\nmoves characters closer and further apart.",
@@ -260,34 +199,17 @@ EventDesc Reversal = {
     .jumpTableIndex = JUMP_REVERSAL,
     .CSSType = SLCHRKIND_TRAINING,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Reversal_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData SDI_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_FOX,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
-};
 EventDesc SDI = {
     .eventName = "SDI Training\n",
     .eventDescription = "Use Smash DI to escape\nFox's up-air!",
@@ -295,14 +217,15 @@ EventDesc SDI = {
     .jumpTableIndex = JUMP_SDITRAINING,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_FOX,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &SDI_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 
 };
 
@@ -319,9 +242,6 @@ static EventMatchData Powershield_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_FALCO,
-    .stage = GRKINDEXT_FD,
     .timerSeconds = 0,
 };
 EventDesc Powershield = {
@@ -331,32 +251,15 @@ EventDesc Powershield = {
     .jumpTableIndex = -1,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_FALCO,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = true,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
     .matchData = &Powershield_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
-};
-static EventMatchData Ledgetech_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_FALCO,
-    .stage = -1,
-    .timerSeconds = 0,
 };
 EventDesc Ledgetech = {
     .eventName = "Ledge-Tech Training\n",
@@ -365,34 +268,17 @@ EventDesc Ledgetech = {
     .jumpTableIndex = JUMP_LEDGETECH,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = CKIND_FALCO,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Ledgetech_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData AmsahTech_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_MARTH,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc AmsahTech = {
     .eventName = "Amsah-Tech Training\n",
     .eventDescription = "Taunt to have Marth Up-B,\nthen ASDI down and tech!\n",
@@ -400,34 +286,17 @@ EventDesc AmsahTech = {
     .jumpTableIndex = JUMP_AMSAHTECH,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = CKIND_MARTH,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &AmsahTech_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData ShieldDrop_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc ShieldDrop = {
     .eventName = "Shield Drop Training\n",
     .eventDescription = "Counter with a shield-drop aerial!\nDPad left/right moves players apart.",
@@ -435,32 +304,15 @@ EventDesc ShieldDrop = {
     .jumpTableIndex = JUMP_SHIELDDROP,
     .CSSType = SLCHRKIND_TRAINING,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &ShieldDrop_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
-};
-static EventMatchData WaveshineSDI_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_FOX,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
+    .matchData = 0,
 };
 EventDesc WaveshineSDI = {
     .eventName = "Waveshine SDI\n",
@@ -474,34 +326,17 @@ EventDesc WaveshineSDI = {
                     | CSSID_SAMUS | CSSID_ZELDA | CSSID_LINK,
         .cpu = -1,
     },
-    .isSelectStage = false,
+    .playerKind = CKIND_FOX,
+    .cpuKind = -1,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &WaveshineSDI_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData SlideOff_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_MARTH,
-    .stage = GRKINDEXT_PSTAD,
-    .timerSeconds = 0,
-};
 EventDesc SlideOff = {
     .eventName = "Slide-Off Training\n",
     .eventDescription = "Use Slide-Off DI to slide off\nthe platform and counter attack!\n",
@@ -509,34 +344,17 @@ EventDesc SlideOff = {
     .jumpTableIndex = JUMP_SLIDEOFF,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_MARTH,
+    .stage = GRKINDEXT_PSTAD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &SlideOff_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData GrabMash_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_MARTH,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
-};
 EventDesc GrabMash = {
     .eventName = "Grab Mash Training\n",
     .eventDescription = "Mash buttons to escape the grab\nas quickly as possible!\n",
@@ -544,32 +362,15 @@ EventDesc GrabMash = {
     .jumpTableIndex = JUMP_GRABMASH,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_MARTH,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &GrabMash_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
-};
-static EventMatchData TechCounter_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_MARTH,
-    .stage = -1,
-    .timerSeconds = 0,
+    .matchData = 0,
 };
 EventDesc TechCounter = {
     .eventName = "Ledgetech Marth Counter\n",
@@ -581,14 +382,15 @@ EventDesc TechCounter = {
         .hmn = CSSID_FALCO | CSSID_FOX,
         .cpu = -1,
     },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = CKIND_MARTH,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &TechCounter_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
 static EventMatchData Edgeguard_MatchData = {
@@ -604,9 +406,6 @@ static EventMatchData Edgeguard_MatchData = {
     .isRunStockLogic = false,
     .isDisableHit = false,
     .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
     .timerSeconds = 0,
 };
 EventDesc Edgeguard = {
@@ -620,34 +419,17 @@ EventDesc Edgeguard = {
         .cpu = CSSID_FOX | CSSID_FALCO | CSSID_ZELDA | CSSID_CAPTAIN_FALCON
             | CSSID_MARTH
     },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
     .matchData = &Edgeguard_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
 };
 
-static EventMatchData SideBSweet_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_MARTH,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc SideBSweet = {
     .eventName = "Side-B Sweetspot\n",
     .eventDescription = "Use a sweetspot Side-B to avoid Marth's\ndown-tilt and grab the ledge!",
@@ -658,32 +440,15 @@ EventDesc SideBSweet = {
         .hmn = CSSID_FALCO | CSSID_FOX,
         .cpu = -1,
     },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = CKIND_MARTH,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &SideBSweet_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
-};
-static EventMatchData EscapeSheik_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_SHEIK,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
+    .matchData = 0,
 };
 EventDesc EscapeSheik = {
     .eventName = "Escape Sheik Techchase\n",
@@ -695,34 +460,17 @@ EventDesc EscapeSheik = {
         .hmn = CSSID_YOSHI |  CSSID_CAPTAIN_FALCON |  CSSID_FALCO |  CSSID_FOX |  CSSID_PIKACHU,
         .cpu = -1,
     },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_SHEIK,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &EscapeSheik_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData Eggs_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = -1,
-    .timerSeconds = 0,
-};
 EventDesc Eggs = {
     .eventName = "Eggs-ercise\n",
     .eventDescription = "Break the eggs! Only strong hits will\nbreak them. DPad down = free practice.",
@@ -730,32 +478,15 @@ EventDesc Eggs = {
     .jumpTableIndex = JUMP_EGGS,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = true,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = -1,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Eggs_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
-};
-static EventMatchData Multishine_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
+    .matchData = 0,
 };
 EventDesc Multishine = {
     .eventName = "Shined Blind\n",
@@ -767,34 +498,17 @@ EventDesc Multishine = {
         .hmn = CSSID_FALCO | CSSID_FOX,
         .cpu = -1,
     },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Multishine_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData Reaction_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = CKIND_FOX,
-    .stage = GRKINDEXT_FD,
-    .timerSeconds = 0,
-};
 EventDesc Reaction = {
     .eventName = "Reaction Test\n",
     .eventDescription = "Test your reaction time by pressing\nany button when you see/hear Fox shine!",
@@ -802,34 +516,17 @@ EventDesc Reaction = {
     .jumpTableIndex = JUMP_REACTION,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = CKIND_FOX,
+    .stage = GRKINDEXT_FD,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_KO,
     .callbackPriority = 3,
-    .matchData = &Reaction_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
-static EventMatchData Ledgestall_MatchData = {
-    .timer = MATCH_TIMER_COUNTUP,
-    .matchType = MATCH_MATCHTYPE_TIME,
-    .hideGo = true,
-    .hideReady = true,
-    .isCreateHUD = true,
-    .timerRunOnPause = false,
-    .isCheckForZRetry = true,
-    .isShowScore = false,
-
-    .isRunStockLogic = false,
-    .isDisableHit = false,
-    .useKOCounter = false,
-    .playerKind = -1,
-    .cpuKind = -1,
-    .stage = GRKINDEXT_ZEBES,
-    .timerSeconds = 0,
-};
 EventDesc Ledgestall = {
     .eventName = "Under Fire\n",
     .eventDescription = "Ledgestall to remain\ninvincible while the lava rises!\n",
@@ -837,14 +534,15 @@ EventDesc Ledgestall = {
     .jumpTableIndex = JUMP_LEDGESTALL,
     .CSSType = SLCHRKIND_EVENT,
     .allowed_characters = { .hmn = -1, .cpu = -1 },
-    .isSelectStage = false,
+    .playerKind = -1,
+    .cpuKind = -1,
+    .stage = GRKINDEXT_ZEBES,
     .use_savestates = false,
     .disable_hazards = true,
     .force_sopo = false,
     .scoreType = SCORETYPE_TIME,
     .callbackPriority = 3,
-    .matchData = &Ledgestall_MatchData,
-    .defaultOSD = 0xFFFFFFFF,
+    .matchData = 0,
 };
 
 ///////////////////////
@@ -1018,14 +716,11 @@ void EventInit(int page, int eventID, MatchInit *matchData)
         matchData->playerData[0].isRumble = CSS_GetNametagRumble(0, nametag);
 
         // Determine the CPU
-        s32 cpu_kind;
-        s32 cpu_costume;
-        if (eventMatchData->cpuKind == -1 && event->CSSType == SLCHRKIND_TRAINING) {
+        s32 cpu_kind = event->cpuKind;
+        s32 cpu_costume = 0;
+        if (cpu_kind == -1 && event->CSSType == SLCHRKIND_TRAINING) {
             cpu_kind = preload->queued.fighters[1].kind;
             cpu_costume = preload->queued.fighters[1].costume;
-        } else {
-            cpu_kind = eventMatchData->cpuKind;
-            cpu_costume = 0;
         }
 
         if (cpu_kind == CKIND_ZELDA)
@@ -1062,7 +757,11 @@ void EventInit(int page, int eventID, MatchInit *matchData)
         matchData->playerData[i].isEntry = false;
 
     // Determine the Stage
-    matchData->stage = event->isSelectStage ? preload->queued.stage : eventMatchData->stage;
+    if (event->stage == -1) {
+        matchData->stage = preload->queued.stage;
+    } else {
+        matchData->stage = event->stage;
+    }
 };
 
 void EventLoad()
@@ -4167,22 +3866,22 @@ u8 GetCSSType(int page, int event)
 u8 GetIsSelectStage(int page, int event)
 {
     EventDesc *thisEvent = GetEventDesc(page, event);
-    return (thisEvent->isSelectStage);
+    return (thisEvent->stage == -1);
 }
 s8 GetFighter(int page, int event)
 {
     EventDesc *thisEvent = GetEventDesc(page, event);
-    return (thisEvent->matchData->playerKind);
+    return (thisEvent->playerKind);
 }
 s8 GetCPUFighter(int page, int event)
 {
     EventDesc *thisEvent = GetEventDesc(page, event);
-    return (thisEvent->matchData->cpuKind);
+    return (thisEvent->cpuKind);
 }
 s16 GetStage(int page, int event)
 {
     EventDesc *thisEvent = GetEventDesc(page, event);
-    return (thisEvent->matchData->stage);
+    return (thisEvent->stage);
 }
 u8 GetScoreType(int page, int event)
 {

--- a/src/events.h
+++ b/src/events.h
@@ -62,9 +62,6 @@ typedef struct EventMatchData //r8
     unsigned int isRunStockLogic : 1;
     unsigned int isDisableHit : 1;
     unsigned int useKOCounter : 1;
-    s8 playerKind;                    // -1 = use selected fighter
-    s8 cpuKind;                       // -1 = no CPU
-    s16 stage;                        // -1 = use selected stage
     unsigned int timerSeconds : 32;   // 0xFFFFFFFF
 } EventMatchData;
 enum CSSID {
@@ -127,16 +124,17 @@ typedef struct EventDesc
     char *eventFile;
     int jumpTableIndex;
     char *eventCSSFile;
-    u8 isSelectStage : 1;
     u8 use_savestates : 1;  // enables dpad left and right savestates
     u8 disable_hazards : 1; // removes stage hazards
     u8 force_sopo : 1;
     u8 CSSType;
     AllowedCharacters allowed_characters;
+    s8 playerKind;                    // -1 = use selected fighter
+    s8 cpuKind;                       // -1 = no CPU
+    s16 stage;                        // -1 = use selected stage
     u8 scoreType;
     u8 callbackPriority;
     EventMatchData *matchData;
-    int defaultOSD;
 } EventDesc;
 typedef struct EventPage
 {

--- a/src/lab_css.c
+++ b/src/lab_css.c
@@ -56,8 +56,7 @@ void OnCSSLoad(HSD_Archive *archive)
     // HUGE HACK ALERT -- manually gets function offset of TM_GetEventDesc
     EventDesc *(*GetEventDesc)(int page, int event) = RTOC_PTR(TM_FUNC + (1 * 4));
     event_desc = GetEventDesc(1, 0);
-    event_desc->isSelectStage = 1;
-    event_desc->matchData->stage = -1;
+    event_desc->stage = -1;
     *onload_fileno = -1;
 
     Cam_Button_Create();
@@ -1107,8 +1106,7 @@ void Menu_Confirm_Think(GOBJ *menu_gobj)
             *stc_css_exitkind = 1;
 
             // HUGE HACK ALERT
-            event_desc->isSelectStage = 0;
-            event_desc->matchData->stage = stage_kind;
+            event_desc->stage = stage_kind;
             *onload_fileno = import_data.file_info[this_file_index].file_no;
             *onload_slot = import_data.memcard_slot;
             


### PR DESCRIPTION
Legacy events don't run `EventInit`, so they don't really use `EventMatchData`. Many of the options in the `EventMatchData` don't make sense to have for C events or have obvious defaults, so I removed them and/or added sensible defaults for them in `EventInit`

For example, `showAnalogStick` is the setting that shows the grey stick moving around in the vanilla pause menu. C events don't use the vanilla pause menu, and even if they did the default is fine, so I removed that setting.

Every legacy event had an `EventMatchData` struct defined even though it mostly went unused. Most of the fields have no effect. The only three that are used were pkind, cpukind, and stage. I moved them into `EventDesc` which makes more sense anyways. Then I was able to delete the unused structs for legacy events.

I think these changes help make it easier for developers to add new events and understand what's happening in the code.