### PR TITLE
Reset sub character's CPULeader log on save state load.

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1446,6 +1446,26 @@ int Savestate_Load(Savestate *savestate, int flags)
                 }
             }
 
+            // if subchar exists, reset its leader log, tracked position, and facing
+            if (queue[1].fighter != 0 && savestate->ft_state[i].data[1].is_exist == 1){
+
+                FtSaveStateData *primarychar_data = &ft_state->data[0];
+                FtSaveStateData *subchar_data = &ft_state->data[1];
+                FighterData *primarychar_fighter_data = queue[0].fighter_data;
+                FighterData *subchar_fighter_data = queue[1].fighter_data;
+
+                for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++){
+
+                    CPULeaderLog *log = &subchar_fighter_data->cpu.leader_log[j];
+                    //clear out log entry
+                    subchar_fighter_data->cpu.leader_log[j] = (struct CPULeaderLog){0};
+                    //set the pos target to the primary character's position to avoid a force target at 0,0,0
+                    log->pos = primarychar_data->phys.pos;
+                    //set the facing direction to the primary character's facing direction to avoid an obo flip
+                    log->facing_direction = primarychar_data->facing_direction;
+                }
+            }
+
             // check to recreate HUD
             MatchHUDElement *hud = &stc_matchhud->element_data[i];
 

--- a/src/events.c
+++ b/src/events.c
@@ -1455,7 +1455,6 @@ int Savestate_Load(Savestate *savestate, int flags)
                 FighterData *subchar_fighter_data = queue[1].fighter_data;
 
                 for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++){
-
                     CPULeaderLog *log = &subchar_fighter_data->cpu.leader_log[j];
                     //clear out log entry
                     subchar_fighter_data->cpu.leader_log[j] = (struct CPULeaderLog){0};

--- a/src/events.c
+++ b/src/events.c
@@ -1446,19 +1446,24 @@ int Savestate_Load(Savestate *savestate, int flags)
                 }
             }
 
-            // if subchar exists, reset its leader log, tracked position, and facing
+            // If subchar exists, reset its leader log, tracked position, and facing direction. 
+            // This is to fix a bug where the last 30 frames before save state reset would get carried into the subcharacter's
+            // queue after loading a savestate. A more ideal fix would be to save and restore the cpu leader log, but implementing
+            // that will have to wait until the upcomming save state refactor is done. For now this solves most problems by clearing
+            // out the queue on reset so the subcharacter starts with a blank cpu log, which is what you want in most situations. 
             if (queue[1].fighter != 0 && savestate->ft_state[i].data[1].is_exist == 1){
 
                 FtSaveStateData *primarychar_data = &ft_state->data[0];
                 FighterData *subchar_fighter_data = queue[1].fighter_data;
 
-                for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++)
+                for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++) 
                 {
                     // set the pos target to the primary character's position to avoid a force target at 0,0,0
-                    // set the facing direction to the primary character's facing direction to avoid an obo flip
+                    // set the facing direction to the primary character's facing direction to avoid the facing direction being incorrect on the first frame
                     subchar_fighter_data->cpu.leader_log[j] = (struct CPULeaderLog){
                         .pos = primarychar_data->phys.pos,
-                        .facing_direction = primarychar_data->facing_direction};
+                        .facing_direction = primarychar_data->facing_direction
+                    };
                 }
             }
 

--- a/src/events.c
+++ b/src/events.c
@@ -1450,18 +1450,15 @@ int Savestate_Load(Savestate *savestate, int flags)
             if (queue[1].fighter != 0 && savestate->ft_state[i].data[1].is_exist == 1){
 
                 FtSaveStateData *primarychar_data = &ft_state->data[0];
-                FtSaveStateData *subchar_data = &ft_state->data[1];
-                FighterData *primarychar_fighter_data = queue[0].fighter_data;
                 FighterData *subchar_fighter_data = queue[1].fighter_data;
 
-                for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++){
-                    CPULeaderLog *log = &subchar_fighter_data->cpu.leader_log[j];
-                    //clear out log entry
-                    subchar_fighter_data->cpu.leader_log[j] = (struct CPULeaderLog){0};
-                    //set the pos target to the primary character's position to avoid a force target at 0,0,0
-                    log->pos = primarychar_data->phys.pos;
-                    //set the facing direction to the primary character's facing direction to avoid an obo flip
-                    log->facing_direction = primarychar_data->facing_direction;
+                for (int j = 0; j < countof(subchar_fighter_data->cpu.leader_log); j++)
+                {
+                    // set the pos target to the primary character's position to avoid a force target at 0,0,0
+                    // set the facing direction to the primary character's facing direction to avoid an obo flip
+                    subchar_fighter_data->cpu.leader_log[j] = (struct CPULeaderLog){
+                        .pos = primarychar_data->phys.pos,
+                        .facing_direction = primarychar_data->facing_direction};
                 }
             }
 


### PR DESCRIPTION
After synching fighter data, reset the cpu log of all sub characters (nana).

This prevents a bug where moves, orientation, and popo force from the last x frames before resetting a save state will carry over post savestate load. 