### PR TITLE
Draw SDI lines in lab when DI draw is on

### DIFF
--- a/src/lab.c
+++ b/src/lab.c
@@ -2928,7 +2928,7 @@ void DIDraw_GX()
                         .z_update_enable = true,
                         .z_logic_eq = true,
                         .z_logic_lt = true,
-                        .shape = PRIM_SHAPE_POINTS,
+                        .shape = PRIM_SHAPE_LINE_STRIP,
                     };
                     PRIM_BlendMode blend_mode = { 0 };
                     PRIM_NEW(vertex_num, draw_mode, blend_mode);


### PR DESCRIPTION
Mostly just copied over DI draw code. SDI lines are kept on screen for 30 frames to make them easier to see. A maximum of 10 lines will be rendered. 

Let me know if you have any feedback.