### PR TITLE
Add Forward/Down Throw option to Nana Throw menu

### DIFF
--- a/ASM/training-mode/Misc/Character Randomness/Nana Throw.asm
+++ b/ASM/training-mode/Misc/Character Randomness/Nana Throw.asm
@@ -9,6 +9,9 @@
     cmpwi r3, 0 # 0 = default setting
     beq Exit
 
+    cmpwi r3, 5
+    beq FwdDownThrow         # value 5: skip zeroing, use raw f1 for coin flip
+
     lfd f31, -0x6F88(rtoc) # loads 0.25
     fsubs f1, f1, f1       # f1 = 0.0
 
@@ -20,6 +23,15 @@
     beq Uthrow
     cmpwi r3, 4
     beq Dthrow
+    b Exit
+
+FwdDownThrow:
+    lfs f0, -0x6F94(rtoc)
+    fcmpo cr0, f1, f0
+    lfd f31, -0x6F88(rtoc)
+    fsubs f1, f1, f1
+    bge Fthrow
+    b Dthrow
 
     # The CPU AI throws randomly based on a random float. Each throw has a 0.25
     # probablitity [0,.25)=up, [.25,.5)=down, [.5,.75)=fwd, [.75,1)=back

--- a/src/lab.h
+++ b/src/lab.h
@@ -1450,7 +1450,7 @@ static const char *LabValues_CharacterRng_Misfire[] =
 static const char *LabValues_CharacterRng_Hammer[] =
     { "Default", "1", "2", "3", "4", "5", "6", "7", "8", "9" };
 static const char *LabValues_CharacterRng_NanaThrow[] =
-    { "Default", "Forward Throw", "Backward Throw", "Up Throw", "Down Throw" };
+    { "Default", "Forward Throw", "Backward Throw", "Up Throw", "Down Throw", "Forward/Down Throw" };
     
 static EventOption LabOptions_CharacterRngPeach[] = {
     {


### PR DESCRIPTION
When selected, Nana will forward throw 50% of the time and downthrow 50% of the time. Useful functionality for RNG handoff practice.