### PR TITLE
Dim watermark during idle screen

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -1368,7 +1368,7 @@ void Event_IncTimer(GOBJ *gobj)
 void TM_CreateWatermark(void)
 {
     // create text canvas
-    int canvas = Text_CreateCanvas(10, 0, 9, 13, 0, 14, 0, 19);
+    int canvas = Text_CreateCanvas(10, 0, 9, 13, 0, 14, 0, 10);
     
     // create text
     Text *text = Text_CreateText(10, canvas);


### PR DESCRIPTION
The "TM-CE v1.4" version watermark was remaining at full brightness when the idle screen activated, causing burn-in in some cases.  The solution is lowering the `cobj_gxpri` parameter from 19 to 10 in `TM_CreateWatermark`. This causes the watermark to render under the overlay, so the overlay naturally dims it along with the rest of the screen. I settled on 10 through trial and error, it seems to be the highest value that still gets dimmed.