### PR TITLE
Fix hitbox trails re-rendering after savestate reload

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -264,6 +264,7 @@ typedef struct EventVars
     void (*HUD_DrawText)(const char *text, Rect *pos, float size);
     void (*HUD_DrawActionLogBar)(u8 *action_log, GXColor *color_lookup, int log_count);
     void (*HUD_DrawActionLogKey)(char **action_names, GXColor *action_colors, int action_count);
+    void (*HitboxTrails_Clear)(void);
 } EventVars;
 #define event_vars_ptr_loc ((EventVars**)0x803d7054)
 #define event_vars (*event_vars_ptr_loc)

--- a/src/lab.c
+++ b/src/lab.c
@@ -4,6 +4,8 @@
 #include <stddef.h>
 
 // Static Variables
+u32 hitbox_trail_i;
+HitboxTrail hitbox_trails[64];
 static DIDraw didraws[6];
 static SDIDraw sdidraws[6];
 static GOBJ *infodisp_gobj_hmn;
@@ -5925,6 +5927,8 @@ void Event_Init(GOBJ *gobj)
     GObj_AddProc(gobj, Event_PostThink, 20);
     GObj_AddGXLink(gobj, HitboxTrails_GX, 5, 0);
 
+    event_vars->HitboxTrails_Clear = HitboxTrails_Clear;
+
     // Init runtime options...
     
     // recovery options
@@ -6709,6 +6713,11 @@ static HitboxTrail *HitboxTrails_Add(void) {
     HitboxTrail *trail = &hitbox_trails[hitbox_trail_i];
     hitbox_trail_i = (hitbox_trail_i + 1) % countof(hitbox_trails);
     return trail;
+}
+
+void HitboxTrails_Clear(void) {
+    memset(hitbox_trails, 0, sizeof(hitbox_trails));
+    hitbox_trail_i = 0;
 }
 
 static GXColor HitboxTrails_Color(int dmg) {

--- a/src/lab.h
+++ b/src/lab.h
@@ -113,6 +113,7 @@ void ActionLog_GX(GOBJ *gobj, int pass);
 void ActionLog_Think(void);
 void HitboxTrails_GX(GOBJ *gobj, int pass);
 void HitboxTrails_Think(void);
+void HitboxTrails_Clear(void);
 void DIDraw_Init(void);
 void DIDraw_Reset(int ply);
 void DIDraw_Update(void);
@@ -1915,8 +1916,8 @@ typedef struct HitboxTrail {
     int frame_created;
 } HitboxTrail;
 
-static u32 hitbox_trail_i;
-static HitboxTrail hitbox_trails[64];
+extern u32 hitbox_trail_i;
+extern HitboxTrail hitbox_trails[64];
 
 enum hitbox_trails_option
 {

--- a/src/savestate_v1.c
+++ b/src/savestate_v1.c
@@ -593,6 +593,10 @@ int Savestate_Load_v1(Savestate_v1 *savestate, int flags)
         match->time_frames = savestate->frame;
         event_vars->game_timer = savestate->frame;
 
+        // clear stale hitbox trail entries so they don't replay after reload
+        if (event_vars->HitboxTrails_Clear)
+            event_vars->HitboxTrails_Clear();
+
         // update timer
         int frames = match->time_frames - 1; // this is because the scenethink function runs once before the gobj procs do
         match->time_seconds = frames / 60;


### PR DESCRIPTION
https://imgur.com/a/L8HnnTS
https://discord.com/channels/1287883534182256661/1492786932722438225/1492786932722438225

Fixes a bug reported in discord where old hitboxes would render upon re-loading a savestate. I recommend checking the imgur link for clarity on the bug. Fixed by clearing the hitbox_trails buffer when a savestate load is detected.