### PR TITLE
Add accumulated damage to eggs-ercise

### DIFF
--- a/src/eggs.c
+++ b/src/eggs.c
@@ -3,6 +3,7 @@
 
 static int egg_counter = 0;
 static int high_score = 0;
+static int accumulated_damage = 0;
 static Vec3 coll_pos, last_coll_pos;
 static GOBJ *egg_gobj;
 static CmSubject *cam;
@@ -120,6 +121,7 @@ GOBJ *Egg_Spawn(void)
 
     last_coll_pos = coll_pos;
 
+    accumulated_damage = 0;
     return Item_CreateItem2(&item_egg);
 }
 
@@ -127,8 +129,8 @@ int Egg_OnTakeDamage(GOBJ *gobj)
 {
     // gfx and sfx
     ItemData *egg_data = egg_gobj->userdata;
-    int damage = egg_data->dmg.recent;
-    if (damage >= Options_Main[OPT_DAMAGETHRESHOLD].val){
+    accumulated_damage += egg_data->dmg.recent;
+    if (accumulated_damage >= Options_Main[OPT_DAMAGETHRESHOLD].val){
         Effect_SpawnSync(1232, gobj, egg_data->pos);
         Item_PlayOnDestroySFXAgain(egg_data, 244, 127, 64);
         


### PR DESCRIPTION
From CookBook on discord:
"Eggs-ercise has always been rather scuffed for icies due to their individual hits having low damage and as a result the amount of moves that can break eggs is very limited + the mode doesn't incentivise maintaining sync'd control of the climbers.

Eggs breaking on a cumulative damage threshold would fix these issues and potentially benefit other characters with decent multi-hitting moves in the game mode."