### PR TITLE
Ice Climbers PNJ osd

### DIFF
--- a/src/osds.c
+++ b/src/osds.c
@@ -145,7 +145,7 @@ static void RunOsd_Handoff(GOBJ *thrower, GOBJ *grabber, GOBJ *enemy, HandoffSta
     if (should_tick_handoff) {
         //this number of frames after the enemy is released from the throw, the handoff is considered invalid,
         //even if you successfully regrab. a successful regrab after this timeout is likely a chain grab or backtrack.
-        const int post_release_Timeout = 15;
+        const int post_release_timeout = 15;
         if (state->enemy_release_frame == 0 && IsThrownState(enemy_data->TM.state_prev[0]) && !IsThrownState(enemy_data->state_id)) {
             state->enemy_release_frame = stc_match->time_frames;
         }
@@ -171,7 +171,7 @@ static void RunOsd_Handoff(GOBJ *thrower, GOBJ *grabber, GOBJ *enemy, HandoffSta
             Text_SetColor(msg->text, 1, &stc_msg_colors[color_timing]);
             state->osd_start_frame = 0;
         }
-        else if (state->enemy_release_frame != 0 && state->first_grab_hitbox_frame != 0 && stc_match->time_frames - state->enemy_release_frame > post_release_Timeout) {
+        else if (state->enemy_release_frame != 0 && state->first_grab_hitbox_frame != 0 && stc_match->time_frames - state->enemy_release_frame > post_release_timeout) {
             int grab_to_throw_delta = state->first_grab_hitbox_frame - state->enemy_release_frame;
             bool grab_early = grab_to_throw_delta < 1;
             //if the timing was 'perfect', yet you missed, give a custom error message to avoid confusion.
@@ -193,6 +193,68 @@ static void RunOsd_Handoff(GOBJ *thrower, GOBJ *grabber, GOBJ *enemy, HandoffSta
         state->first_grab_hitbox_frame = 0;
     }
     state->thrower_prev_state = thrower_data->state_id;
+}
+
+static void RunOsd_PnJ(GOBJ *ft, GOBJ *ft_sub) {
+    static int pivot_frames[6] = {};
+    static int jump_frames[6] = {};
+    static char smash_x_prev[6] = {};
+    if (!ft || !ft_sub) return;
+    const FighterData *ft_data = ft->userdata;
+    const FighterData *ft_sub_data = ft_sub->userdata;
+    if (ft_data->kind != FTKIND_POPO) return;
+
+    bool pivot_was_active = pivot_frames[ft_data->ply] != 0;
+
+    //SUCCESSFUL AND LATE PNJ DETECTION
+    if (pivot_frames[ft_data->ply] != 0) {
+        const int late_pnj_window = 4;
+        const int timeout = 6 + late_pnj_window;
+        //timeout.
+        if (stc_match->time_frames >  pivot_frames[ft_data->ply] + timeout) {
+            pivot_frames[ft_data->ply] = 0;
+        }
+        //fail: popo jumped late.
+        else if (ft_data->state_id == ASID_KNEEBEND && stc_match->time_frames - pivot_frames[ft_data->ply] <= late_pnj_window) {
+            int delta = stc_match->time_frames - pivot_frames[ft_data->ply];
+            Message_Display(OSD_FighterSpecificTech, ft_data->ply, MSGCOLOR_RED, "PNJ Fail. %dF Late", delta);
+            pivot_frames[ft_data->ply] = 0;
+        }
+        //success: nana jumped 6f after the smash turn, and popo never jumped.
+        else if (ft_sub_data->state_id == ASID_KNEEBEND && stc_match->time_frames - pivot_frames[ft_data->ply] == 6) {
+            Message_Display(OSD_FighterSpecificTech, ft_data->ply, MSGCOLOR_GREEN, "PNJ Success");
+            pivot_frames[ft_data->ply] = 0;
+        }
+    }
+    //start watching for pnjs after a pivot out of a dash.
+    else if (ft_data->TM.state_prev[0] == ASID_DASH && (ft_data->state_id == ASID_TURN || ft_data->state_id == ASID_TURNRUN)) {
+        pivot_frames[ft_data->ply] = stc_match->time_frames;
+    }
+
+    // EARLY PNJ DETECTION
+    char smash_x = ft_data->input.timer_lstick_smash_x;
+    //smash turns are saved as a decaying byte. if this is < the current frame value, you smash turned this frame.
+    bool smash_input_this_frame = smash_x > smash_x_prev[ft_data->ply];
+    smash_x_prev[ft_data->ply] = smash_x;
+    if (jump_frames[ft_data->ply] != 0) {
+        const int early_pnj_window = 4;
+        int frames_since_jump = stc_match->time_frames - jump_frames[ft_data->ply];
+        //timer_lstick_smash_x reads 1f stale vs state_id, so the real gap is one less.
+        int frames_early = frames_since_jump - 1;
+        bool smash_turn_correct_direction = ft_data->input.lstick.X * ft_data->facing_direction < 0.0f; //to filter out fox trots.
+
+        if (smash_input_this_frame && smash_turn_correct_direction && frames_early >= 1 && frames_early <= early_pnj_window) {
+            Message_Display(OSD_FighterSpecificTech, ft_data->ply, MSGCOLOR_RED, "PNJ Fail. %dF Early", frames_early);
+            jump_frames[ft_data->ply] = 0;
+        }
+        else if (frames_early > early_pnj_window) {
+            jump_frames[ft_data->ply] = 0;
+        }
+    }
+    // check if popo jumped out of a dash to start early pnj detection
+    else if (!pivot_was_active && ft_data->TM.state_prev[0] == ASID_DASH && ft_data->state_id == ASID_KNEEBEND) {
+        jump_frames[ft_data->ply] = stc_match->time_frames;
+    }
 }
 
 void OSD_Think(GOBJ *event) {
@@ -219,6 +281,8 @@ void OSD_Think(GOBJ *event) {
                 RunOsd_Handoff(ft, ft_sub, enm_ft, &handoff_states[ply][0]);
                 RunOsd_Handoff(ft_sub, ft, enm_ft, &handoff_states[ply][1]);
             }
+            RunOsd_PnJ(ft, ft_sub);
+            // ICE CLIMBERS OSDS END
         }
     }
 }


### PR DESCRIPTION
Adding a fighter specific tech osd for the ice climbers. This detects if the player has done, or attempted a pivot nana jump, also known as a PNJ. A PNJ is performed when the primary climber inputs a jump the same frame they do a pivot (empty or dash dance) out of a dash. The main climber cannot jump while in the turn state, which eats the input. The backup climber does not enter the turn state, allowing it to jump freely. This results in a sequence where the main climber empty pivots or dash dances, while the backup climber does a solo jump. 

I added in a window for detection as well to report if you are early or late by up to 4 frames. 