### PR TITLE
Add "100m Dash" event (timed Home Run Contest sprint)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,9 +18,49 @@ If you have any questions, feel free to ping me (Aitch) in the dev-discussion ch
 ### Linux / MacOS / WSL / MSYS2
 1. [Install DevKitPro](https://devkitpro.org/wiki/Getting_Started#Unix-like_platforms). Install the Gamecube (gamecube-dev) package.
 2. Install xdelta3. This should be simple to install through your package manager.
-3. Run the command `./build.sh path-to-melee.iso` in the console.
+3. Run the command `DEVKITPPC=/opt/devkitpro/devkitPPC ./build.sh path-to-melee.iso` in the console.
     - If the provided binaries fail (possibly due to libc issues), you can compile your own binaries from my repos:
 [gc_fst](https://github.com/AlexanderHarrison/gc_fst), [hmex](https://github.com/AlexanderHarrison/cdat), [hgecko](https://github.com/AlexanderHarrison/hgecko)
+
+#### Native arm64 macOS (Apple Silicon) Tool Build
+
+The committed `bin/` binaries are Linux x86-64 ELFs and will not run on macOS arm64. Build native replacements as follows:
+
+```bash
+# 1. Build gc_fst and hgecko (Rust — requires cargo)
+mkdir -p /tmp/tmtools && cd /tmp/tmtools
+git clone https://github.com/AlexanderHarrison/gc_fst.git
+git clone https://github.com/AlexanderHarrison/hgecko.git
+( cd gc_fst && cargo build --release )
+( cd hgecko && cargo build --release )
+
+# 2. Build hmex (C project — needs a byteswap.h shim for macOS clang)
+git clone https://github.com/AlexanderHarrison/cdat.git
+mkdir -p /tmp/tmtools/cdat/shim /tmp/tmtools/cdat/build
+cat > /tmp/tmtools/cdat/shim/byteswap.h << 'EOF'
+#pragma once
+#include <stdint.h>
+#define bswap_16(x) __builtin_bswap16(x)
+#define bswap_32(x) __builtin_bswap32(x)
+#define bswap_64(x) __builtin_bswap64(x)
+EOF
+clang -O2 -I/tmp/tmtools/cdat/shim /tmp/tmtools/cdat/src/hmex.c -o /tmp/tmtools/cdat/build/hmex
+
+# 3. Install into bin/ and keep git clean
+cd /path/to/TrainingMode-CommunityEdition
+cp /tmp/tmtools/gc_fst/target/release/gc_fst  bin/gc_fst
+cp /tmp/tmtools/hgecko/target/release/hgecko  bin/hgecko
+cp /tmp/tmtools/cdat/build/hmex               bin/hmex
+chmod +x bin/gc_fst bin/hgecko bin/hmex
+git update-index --skip-worktree bin/gc_fst bin/hgecko bin/hmex
+# Verify: should report Mach-O arm64
+file bin/gc_fst bin/hgecko bin/hmex
+```
+
+Then build normally:
+```bash
+DEVKITPPC=/opt/devkitpro/devkitPPC ./build.sh /path/to/vanilla/melee.iso
+```
 
 ### Build Mode
 The build script takes an optional additional mode argument called the mode - `build.sh iso [mode]`.

--- a/MexTK/include/stage.h
+++ b/MexTK/include/stage.h
@@ -94,6 +94,7 @@ typedef enum GrExternal
     GRKINDEXT_OLDKONGO,
     GRKINDEXT_BATTLE,
     GRKINDEXT_FD,
+    GRKINDEXT_HOMERUN = 84, // Home Run Contest stage (GrHr); external 84 -> GRKIND_HOMERUN, found via spike
 } GrExternal;
 
 typedef enum MapRenderKind

--- a/build.sh
+++ b/build.sh
@@ -85,7 +85,7 @@ mex_build "cssFunction" "build/labCSS.dat" "src/lab_css.c" "dats/labCSS.dat" &
 mex_build "evFunction" "build/lab.dat" "src/lab.c" "dats/lab.dat" &
 mex_build "evFunction" "build/lcancel.dat" "src/lcancel.c" &
 mex_build "evFunction" "build/ledgedash.dat" "src/ledgedash.c" &
-mex_build "evFunction" "build/wavedash.dat" "src/wavedash.c" "dats/wavedash.dat" &
+mex_build "evFunction" "build/wavedash.dat" "src/wavedash.c src/wavedash_common.c" "dats/wavedash.dat" &
 mex_build "evFunction" "build/powershield.dat" "src/powershield.c" &
 mex_build "evFunction" "build/dthrowknee.dat" "src/dthrowknee.c" &
 mex_build "evFunction" "build/edgeguard.dat" "src/edgeguard.c" &

--- a/build.sh
+++ b/build.sh
@@ -95,6 +95,7 @@ mex_build "evFunction" "build/laserland.dat" "src/laserland.c" &
 mex_build "evFunction" "build/eggs.dat" "src/eggs.c" &
 mex_build "evFunction" "build/techchase.dat" "src/techchase.c" &
 mex_build "evFunction" "build/slalom.dat" "src/slalom.c" "dats/wavedash.dat" &
+mex_build "evFunction" "build/xmdash.dat" "src/xmdash.c src/wavedash_common.c" "dats/wavedash.dat" &
 
 # wait for compilation to finish
 wait
@@ -132,6 +133,7 @@ ${gc_fst} fs TM-CE.iso \
     insert TM/eggs.dat build/eggs.dat \
     insert TM/techchase.dat build/techchase.dat \
     insert TM/slalom.dat build/slalom.dat \
+    insert TM/xmdash.dat build/xmdash.dat \
     insert codes.gct build/codes.gct \
     insert Start.dol build/Start.dol \
     insert opening.bnr opening.bnr

--- a/src/events.c
+++ b/src/events.c
@@ -644,6 +644,22 @@ EventDesc Slalom = {
     .matchData = &Slalom_MatchData,
 };
 
+static EventMatchData XmDash_MatchData = {
+    .timer = MATCH_TIMER_HIDE, .matchType = MATCH_MATCHTYPE_TIME,
+    .hideGo = true, .hideReady = true, .isCreateHUD = false,
+    .timerRunOnPause = false, .isCheckForZRetry = true, .isShowScore = false,
+    .isRunStockLogic = false, .isDisableHit = false, .useKOCounter = false, .timerSeconds = 0,
+};
+EventDesc XmDash = {
+    .eventName = "100m Dash\n",
+    .eventDescription = "Sprint the Home Run track as fast\nas you can! Start = options.",
+    .eventFile = "xmdash", .jumpTableIndex = -1, .CSSType = SLCHRKIND_EVENT,
+    .allowed_characters = { .hmn = -1, .cpu = -1 }, .cpuKind = -1,
+    .stage = GRKINDEXT_HOMERUN, // Home Run Contest stage (external 84 -> GRKIND_HOMERUN), confirmed by spike scan
+    .disable_hazards = true, .force_sopo = false,
+    .scoreType = SCORETYPE_TIME, .callbackPriority = 15, .matchData = &XmDash_MatchData, // 15 like Wavedash (not 3): xmdash reuses wavedash's frame-precise timing detection, which must run after the fighter's per-frame state update
+};
+
 EventDesc Multishine = {
     .eventName = "Shined Blind\n",
     .eventDescription = "How many shines can you\nperform in 10 seconds?",
@@ -703,6 +719,7 @@ EventDesc Ledgestall = {
 static EventDesc *Minigames_Events[] = {
     &Eggs,
     &Slalom,
+    &XmDash,
     &Multishine,
     &Reaction,
     &Ledgestall,

--- a/src/wavedash.c
+++ b/src/wavedash.c
@@ -1,12 +1,6 @@
 #include "wavedash.h"
 #include "events.h"
 
-static char *panel_label[3] = {"Timing", "Angle", "Success Rate"};
-static char timing_text[24] = "-";
-static char angle_text[24] = "-";
-static char success_rate_text[24] = "-";
-static char *panel_info[3] = {timing_text, angle_text, success_rate_text};
-
 enum options {
     OPT_TARGET,
     OPT_SHORT_HOP,
@@ -89,8 +83,8 @@ void Event_Init(GOBJ *gobj)
     Target_Init(event_data, hmn_data);
 
     // init vars
-    event_data->timer = -1;
-    event_data->result = -1;
+    event_data->core.timer = -1;
+    event_data->core.result = -1;
     
     GObj_AddGXLink(gobj, HUD_GX, 5, 0);
 }
@@ -105,7 +99,11 @@ void Event_Think(GOBJ *event)
     // infinite shields
     hmn_data->shield.health = 60;
 
-    Wavedash_Think(event_data, hmn_data);
+    WavedashCoreConfig cfg = {
+        .show_hud = WdOptions_Main[OPT_HUD].val,
+        .short_hop_indicator = WdOptions_Main[OPT_SHORT_HOP].val,
+    };
+    WavedashCore_Think(&event_data->core, hmn_data, &cfg);
 
     // update target
     Target_Manager(event_data, hmn_data);
@@ -124,236 +122,13 @@ void Event_Exit(GOBJ *menu)
 
 void HUD_GX(GOBJ *gobj, int pass) {
     WavedashData *event_data = gobj->userdata;
-
-    if (WdOptions_Main[OPT_HUD].val == 0) return;
-    if (pass != 2) return;
-    
-    // Draw info panel
-    event_vars->HUD_DrawInfoPanel((const char**)panel_label, (const char**)panel_info, countof(panel_label));
-
-    #define W 1.6f // width of square
-    #define H 2.f // height of square
-    #define P 0.1f // amount of padding
-    #define SX (-W * 15.f * 0.5f - P/2) // starting x
-    #define SY 16.f // starting y
-    
-    static GXColor colors[16] = {
-        {0, 0, 0, 255}, // background
-        
-        // early
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        {0xff, 0x60, 0x60, 0xff},
-        
-        // interpolate green -> orange
-        { 0xb4, 0xff, 0xb4, 0xff },
-        { 0xc3, 0xf3, 0x99, 0xff },
-        { 0xd5, 0xe3, 0x79, 0xff },
-        { 0xe5, 0xd2, 0x61, 0xff },
-        { 0xf2, 0xc0, 0x51, 0xff },
-        { 0xfc, 0xab, 0x4e, 0xff },
-        { 0xff, 0x9d, 0x54, 0xff },
-        { 0xff, 0x90, 0x60, 0xff },
+    GOBJ *hmn = Fighter_GetGObj(0);
+    FighterData *hmn_data = hmn->userdata;
+    WavedashCoreConfig cfg = {
+        .show_hud = WdOptions_Main[OPT_HUD].val,
+        .short_hop_indicator = WdOptions_Main[OPT_SHORT_HOP].val,
     };
-    
-    static Rect rects[16] = {
-        {SX-P/2, SY, 15.f*W+P, H}, // background
-        {SX+P/2+W*0, SY+P, W-P, H-P*2},
-        {SX+P/2+W*1, SY+P, W-P, H-P*2},
-        {SX+P/2+W*2, SY+P, W-P, H-P*2},
-        {SX+P/2+W*3, SY+P, W-P, H-P*2},
-        {SX+P/2+W*4, SY+P, W-P, H-P*2},
-        {SX+P/2+W*5, SY+P, W-P, H-P*2},
-        {SX+P/2+W*6, SY+P, W-P, H-P*2},
-        {SX+P/2+W*7, SY+P, W-P, H-P*2},
-        {SX+P/2+W*8, SY+P, W-P, H-P*2},
-        {SX+P/2+W*9, SY+P, W-P, H-P*2},
-        {SX+P/2+W*10, SY+P, W-P, H-P*2},
-        {SX+P/2+W*11, SY+P, W-P, H-P*2},
-        {SX+P/2+W*12, SY+P, W-P, H-P*2},
-        {SX+P/2+W*13, SY+P, W-P, H-P*2},
-        {SX+P/2+W*14, SY+P, W-P, H-P*2},
-    };
-    event_vars->HUD_DrawRects(rects, colors, countof(rects));
-
-    Tri tris[countof(event_data->airdodge_frame)*2];
-    GXColor tri_color[countof(event_data->airdodge_frame)*2];
-
-    int ad_count = event_data->airdodge_count;
-    int *ad_frame = event_data->airdodge_frame;
-    GOBJ *ft = Fighter_GetGObj(0);
-    FighterData *hmn_data = ft->userdata;
-    
-    static float x_pos[countof(event_data->airdodge_frame)] = {0};
-    static int show_count = 0;
-
-    if (event_data->timer == -1) {
-        show_count = ad_count;
-
-        // animate
-        for (int i = 0; i < ad_count; ++i) {
-            int f = ad_frame[i];
-            float x = SX + ((float)f + (7.f - hmn_data->attr.jump_startup_time - 1.f) + 0.5f) * W;
-    
-            float px = x_pos[i];
-            float dx = x - px;
-            if (fabs(dx) > 0.01f) 
-                x = px + dx * 0.3f;
-            x_pos[i] = x;
-        }
-    }
-
-    for (int i = 0; i < show_count; ++i) {
-        float x = x_pos[i];
-        float y = SY - 0.8f;
-        int f = ad_frame[i];
-        if (i != 0 && ad_frame[i-1] == f)
-            y -= H;
-        #define B 0.3f
-        #define B2 0.1f
-        #define B3 0.15f
-        tris[i*2+1][0] = (Vec2) {x, y};
-        tris[i*2+1][1] = (Vec2) {x+W*0.3f, y-H*0.6f};
-        tris[i*2+1][2] = (Vec2) {x-W*0.3f, y-H*0.6f};
-        tri_color[i*2+1] = (GXColor) {255, 255, 255, 255};
-
-        tris[i*2+0][0].X = tris[i*2+1][0].X;
-        tris[i*2+0][0].Y = tris[i*2+1][0].Y + 0.3f;
-        tris[i*2+0][1].X = tris[i*2+1][1].X + 0.15f;
-        tris[i*2+0][1].Y = tris[i*2+1][1].Y - 0.1f;
-        tris[i*2+0][2].X = tris[i*2+1][2].X - 0.15f;
-        tris[i*2+0][2].Y = tris[i*2+1][2].Y - 0.1f;
-        tri_color[i*2+0] = (GXColor) {0, 0, 0, 200};
-    }
-
-    event_vars->HUD_DrawTris(tris, tri_color, show_count * 2);
-
-    static Rect early = { SX, SY + 3, 0, 0 };
-    static Rect timing0 = { 0, SY + 4.5f, 0, 0 };
-    static Rect timing1 = { 0, SY + 3, 0, 0 };
-    static Rect late = { -SX, SY + 3, 0, 0 };
-    event_vars->HUD_DrawText("Early", &early, 0.45f);
-    event_vars->HUD_DrawText("Wavedash", &timing0, 0.4f);
-    event_vars->HUD_DrawText("Timing", &timing1, 0.4f);
-    event_vars->HUD_DrawText("Late", &late, 0.45f);
-}
-
-void Wavedash_Think(WavedashData *event_data, FighterData *hmn_data)
-{
-    // start sequence on jump squat
-    if (hmn_data->state_id == ASID_KNEEBEND && hmn_data->TM.state_frame == 0)
-    {
-        event_data->timer = 0;
-        event_data->airdodge_count = 0;
-    }
-
-    // Do nothing if sequence hasn't started
-    if (event_data->timer < 0)
-        return;
-
-    // run sequence logic
-    event_data->timer++;
-
-    // The game tracks whether the current jump is going to be a short hop in
-    // `state_var1`. The value at the end of kneebend is what we want.
-    if (hmn_data->state_id == ASID_KNEEBEND)
-        event_data->short_hop = hmn_data->state_var.state_var1;
-    if (WdOptions_Main[OPT_SHORT_HOP].val && event_data->short_hop)
-        Fighter_ColAnim_Apply(hmn_data, 107, 0); // make sparkles
-    
-    // Record airdodge timings.
-    if (event_data->airdodge_count < (int)countof(event_data->airdodge_frame) && (hmn_data->input.down & PAD_TRIGGER_L))
-        event_data->airdodge_frame[event_data->airdodge_count++] = event_data->timer;
-    if (event_data->airdodge_count < (int)countof(event_data->airdodge_frame) && (hmn_data->input.down & PAD_TRIGGER_R))
-        event_data->airdodge_frame[event_data->airdodge_count++] = event_data->timer;
-
-    // Real airdodge
-    if (hmn_data->TM.state_frame == 0 &&
-            (hmn_data->state_id == ASID_ESCAPEAIR ||
-            (hmn_data->state_id == ASID_LANDINGFALLSPECIAL &&
-             hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR &&
-             hmn_data->TM.state_prev_frames[0] == 0)))
-    {
-        PADStatus *stat = PadGetRaw(hmn_data->pad_index);
-        event_data->angle = -atan2(stat->stickY, fabs(stat->stickX)) / M_1DEGREE;
-    }
-    
-    if (event_data->result == -1) {
-        if (hmn_data->state_id == ASID_LANDINGFALLSPECIAL
-            && hmn_data->TM.state_frame == 0
-            && hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR
-            && hmn_data->TM.state_prev[2] == ASID_KNEEBEND)
-        {
-            // success
-            event_data->wd_attempted++;
-            event_data->wd_succeeded++;
-    
-            // check for perfect
-            int perfect_frame = (int)hmn_data->attr.jump_startup_time + 1;
-            for (int i = 0; i < event_data->airdodge_count; ++i) {
-                if (
-                    event_data->airdodge_frame[i] == perfect_frame
-                    || (event_data->airdodge_frame[i] == perfect_frame+1 && event_data->short_hop)
-                ) {
-                    SFX_Play(303);
-                    break;
-                }
-            }
-            event_data->result = 1;
-        }
-        else if (hmn_data->TM.state_frame >= FAILFRAMES &&
-                event_data->airdodge_count != 0 &&
-                (hmn_data->state_id == ASID_JUMPF ||
-                hmn_data->state_id == ASID_JUMPB ||
-                hmn_data->state_id == ASID_ESCAPEAIR)) {
-            // failure
-            event_data->wd_attempted++;
-            SFX_PlayCommon(3);
-            event_data->result = 0;
-        }
-    }
-    
-    // We need to wait until the wavedash finishes to reset in order to capture late LR presses
-    if (event_data->timer == 13) {
-        // Reset
-        event_data->result = -1;
-        event_data->timer = -1;
-        Fighter_ColAnim_Remove(hmn_data, 107); // remove sparkles
-
-        // Wavedash not attempted
-        if (event_data->airdodge_count == 0)
-            return;
-    
-        // update timing
-        int timing = event_data->airdodge_frame[0] - (int)hmn_data->attr.jump_startup_time - 1;
-        for (int i = 1; i < event_data->airdodge_count; ++i) {
-            int new_timing = event_data->airdodge_frame[i] - (int)hmn_data->attr.jump_startup_time - 1;
-            if (timing < 0)
-                timing = new_timing;
-            else
-                break;
-        } 
-    
-        if (timing < 0)
-            sprintf(timing_text, "%df Early", -timing);
-        else if (timing > 0)
-            sprintf(timing_text, "%df Late", timing);
-        else
-            sprintf(timing_text, "Perfect");
-        
-        // update angle
-        sprintf(angle_text, "%.1f", event_data->angle);
-        
-        // update success rate
-        int success = event_data->wd_succeeded;
-        int attempted = event_data->wd_attempted;
-        float success_rate = (float)success * 100.f / (float)attempted;
-        sprintf(success_rate_text, "%d (%.2f%%)", success, success_rate);
-    }
+    WavedashCore_DrawHUD(&event_data->core, hmn_data, &cfg, pass);
 }
 
 // Target functions
@@ -702,8 +477,8 @@ void Tips_Think(WavedashData *event_data, FighterData *hmn_data)
             && hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR
             && hmn_data->TM.state_prev_frames[0] > 3 // slow to hit ground from airdodge
             && hmn_data->TM.state_prev_frames[1] < 5 // slightly late airdodge timing
-            && event_data->angle > 0            // ignore horizontal airdodge
-            && !event_data->short_hop)               // full hop
+            && event_data->core.angle > 0       // ignore horizontal airdodge
+            && !event_data->core.short_hop)          // full hop
     {
         if (event_data->tip.short_hop++ % 8 == 2)
             event_vars->Tip_Display(5 * 60, "Tip:\nUse short hop for wavedash!\nit can help you land faster\nwhen you airdodge late.");

--- a/src/wavedash.h
+++ b/src/wavedash.h
@@ -1,5 +1,6 @@
 #include "../MexTK/mex.h"
 #include "events.h"
+#include "wavedash_common.h"
 
 #define TEXT_SCALE 4.2
 #define WDJOBJ_TEXT 6
@@ -7,7 +8,6 @@
 #define WDARROW_OFFSET 0.36
 #define WDARROW_ANIMFRAMES 4
 #define WDFRAMES 15
-#define FAILFRAMES 8
 
 #define TRGT_RANGEMAX 0.8
 #define TRGT_RANGEMIN 0.55
@@ -43,14 +43,7 @@ struct WavedashData
         u8 short_hop;
     } tip;
     float wd_maxdstn;
-    int timer;
-    int airdodge_count;
-    int airdodge_frame[8];
-    int result;
-    float angle;
-    int short_hop;
-    int wd_attempted;
-    int wd_succeeded;
+    WavedashCore core;
 };
 
 struct WavedashAssets
@@ -86,7 +79,6 @@ void Target_Think(GOBJ *target_gobj);
 void Target_ChangeState(GOBJ *target_gobj, int state);
 void Target_Manager(WavedashData *event_data, FighterData *hmn_data);
 void Target_Init(WavedashData *event_data, FighterData *hmn_data);
-void Wavedash_Think(WavedashData *event_data, FighterData *hmn_data);
 void Wavedash_ChangeShowHUD(GOBJ *menu_gobj, int show);
 void HUD_GX(GOBJ *gobj, int pass);
 void Event_Exit(GOBJ *menu);

--- a/src/wavedash_common.c
+++ b/src/wavedash_common.c
@@ -1,0 +1,241 @@
+#include "wavedash_common.h"
+#include "events.h"
+
+#define FAILFRAMES 8
+
+static char *panel_label[3] = {"Timing", "Angle", "Success Rate"};
+static char timing_text[24] = "-";
+static char angle_text[24] = "-";
+static char success_rate_text[24] = "-";
+static char *panel_info[3] = {timing_text, angle_text, success_rate_text};
+
+void WavedashCore_DrawHUD(WavedashCore *core, FighterData *hmn_data, const WavedashCoreConfig *cfg, int pass)
+{
+    if (!cfg->show_hud) return;
+    if (pass != 2) return;
+
+    // Draw info panel
+    event_vars->HUD_DrawInfoPanel((const char**)panel_label, (const char**)panel_info, countof(panel_label));
+
+    #define W 1.6f // width of square
+    #define H 2.f // height of square
+    #define P 0.1f // amount of padding
+    #define SX (-W * 15.f * 0.5f - P/2) // starting x
+    #define SY 16.f // starting y
+
+    static GXColor colors[16] = {
+        {0, 0, 0, 255}, // background
+
+        // early
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+        {0xff, 0x60, 0x60, 0xff},
+
+        // interpolate green -> orange
+        { 0xb4, 0xff, 0xb4, 0xff },
+        { 0xc3, 0xf3, 0x99, 0xff },
+        { 0xd5, 0xe3, 0x79, 0xff },
+        { 0xe5, 0xd2, 0x61, 0xff },
+        { 0xf2, 0xc0, 0x51, 0xff },
+        { 0xfc, 0xab, 0x4e, 0xff },
+        { 0xff, 0x9d, 0x54, 0xff },
+        { 0xff, 0x90, 0x60, 0xff },
+    };
+
+    static Rect rects[16] = {
+        {SX-P/2, SY, 15.f*W+P, H}, // background
+        {SX+P/2+W*0, SY+P, W-P, H-P*2},
+        {SX+P/2+W*1, SY+P, W-P, H-P*2},
+        {SX+P/2+W*2, SY+P, W-P, H-P*2},
+        {SX+P/2+W*3, SY+P, W-P, H-P*2},
+        {SX+P/2+W*4, SY+P, W-P, H-P*2},
+        {SX+P/2+W*5, SY+P, W-P, H-P*2},
+        {SX+P/2+W*6, SY+P, W-P, H-P*2},
+        {SX+P/2+W*7, SY+P, W-P, H-P*2},
+        {SX+P/2+W*8, SY+P, W-P, H-P*2},
+        {SX+P/2+W*9, SY+P, W-P, H-P*2},
+        {SX+P/2+W*10, SY+P, W-P, H-P*2},
+        {SX+P/2+W*11, SY+P, W-P, H-P*2},
+        {SX+P/2+W*12, SY+P, W-P, H-P*2},
+        {SX+P/2+W*13, SY+P, W-P, H-P*2},
+        {SX+P/2+W*14, SY+P, W-P, H-P*2},
+    };
+    event_vars->HUD_DrawRects(rects, colors, countof(rects));
+
+    Tri tris[countof(core->airdodge_frame)*2];
+    GXColor tri_color[countof(core->airdodge_frame)*2];
+
+    int ad_count = core->airdodge_count;
+    int *ad_frame = core->airdodge_frame;
+
+    static float x_pos[countof(core->airdodge_frame)] = {0};
+    static int show_count = 0;
+
+    if (core->timer == -1) {
+        show_count = ad_count;
+
+        // animate
+        for (int i = 0; i < ad_count; ++i) {
+            int f = ad_frame[i];
+            float x = SX + ((float)f + (7.f - hmn_data->attr.jump_startup_time - 1.f) + 0.5f) * W;
+
+            float px = x_pos[i];
+            float dx = x - px;
+            if (fabs(dx) > 0.01f)
+                x = px + dx * 0.3f;
+            x_pos[i] = x;
+        }
+    }
+
+    for (int i = 0; i < show_count; ++i) {
+        float x = x_pos[i];
+        float y = SY - 0.8f;
+        int f = ad_frame[i];
+        if (i != 0 && ad_frame[i-1] == f)
+            y -= H;
+        #define B 0.3f
+        #define B2 0.1f
+        #define B3 0.15f
+        tris[i*2+1][0] = (Vec2) {x, y};
+        tris[i*2+1][1] = (Vec2) {x+W*0.3f, y-H*0.6f};
+        tris[i*2+1][2] = (Vec2) {x-W*0.3f, y-H*0.6f};
+        tri_color[i*2+1] = (GXColor) {255, 255, 255, 255};
+
+        tris[i*2+0][0].X = tris[i*2+1][0].X;
+        tris[i*2+0][0].Y = tris[i*2+1][0].Y + 0.3f;
+        tris[i*2+0][1].X = tris[i*2+1][1].X + 0.15f;
+        tris[i*2+0][1].Y = tris[i*2+1][1].Y - 0.1f;
+        tris[i*2+0][2].X = tris[i*2+1][2].X - 0.15f;
+        tris[i*2+0][2].Y = tris[i*2+1][2].Y - 0.1f;
+        tri_color[i*2+0] = (GXColor) {0, 0, 0, 200};
+    }
+
+    event_vars->HUD_DrawTris(tris, tri_color, show_count * 2);
+
+    static Rect early = { SX, SY + 3, 0, 0 };
+    static Rect timing0 = { 0, SY + 4.5f, 0, 0 };
+    static Rect timing1 = { 0, SY + 3, 0, 0 };
+    static Rect late = { -SX, SY + 3, 0, 0 };
+    event_vars->HUD_DrawText("Early", &early, 0.45f);
+    event_vars->HUD_DrawText("Wavedash", &timing0, 0.4f);
+    event_vars->HUD_DrawText("Timing", &timing1, 0.4f);
+    event_vars->HUD_DrawText("Late", &late, 0.45f);
+}
+
+void WavedashCore_Think(WavedashCore *core, FighterData *hmn_data, const WavedashCoreConfig *cfg)
+{
+    // start sequence on jump squat
+    if (hmn_data->state_id == ASID_KNEEBEND && hmn_data->TM.state_frame == 0)
+    {
+        core->timer = 0;
+        core->airdodge_count = 0;
+    }
+
+    // Do nothing if sequence hasn't started
+    if (core->timer < 0)
+        return;
+
+    // run sequence logic
+    core->timer++;
+
+    // The game tracks whether the current jump is going to be a short hop in
+    // `state_var1`. The value at the end of kneebend is what we want.
+    if (hmn_data->state_id == ASID_KNEEBEND)
+        core->short_hop = hmn_data->state_var.state_var1;
+    if (cfg->short_hop_indicator && core->short_hop)
+        Fighter_ColAnim_Apply(hmn_data, 107, 0); // make sparkles
+
+    // Record airdodge timings.
+    if (core->airdodge_count < (int)countof(core->airdodge_frame) && (hmn_data->input.down & PAD_TRIGGER_L))
+        core->airdodge_frame[core->airdodge_count++] = core->timer;
+    if (core->airdodge_count < (int)countof(core->airdodge_frame) && (hmn_data->input.down & PAD_TRIGGER_R))
+        core->airdodge_frame[core->airdodge_count++] = core->timer;
+
+    // Real airdodge
+    if (hmn_data->TM.state_frame == 0 &&
+            (hmn_data->state_id == ASID_ESCAPEAIR ||
+            (hmn_data->state_id == ASID_LANDINGFALLSPECIAL &&
+             hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR &&
+             hmn_data->TM.state_prev_frames[0] == 0)))
+    {
+        PADStatus *stat = PadGetRaw(hmn_data->pad_index);
+        core->angle = -atan2(stat->stickY, fabs(stat->stickX)) / M_1DEGREE;
+    }
+
+    if (core->result == -1) {
+        if (hmn_data->state_id == ASID_LANDINGFALLSPECIAL
+            && hmn_data->TM.state_frame == 0
+            && hmn_data->TM.state_prev[0] == ASID_ESCAPEAIR
+            && hmn_data->TM.state_prev[2] == ASID_KNEEBEND)
+        {
+            // success
+            core->wd_attempted++;
+            core->wd_succeeded++;
+
+            // check for perfect
+            int perfect_frame = (int)hmn_data->attr.jump_startup_time + 1;
+            for (int i = 0; i < core->airdodge_count; ++i) {
+                if (
+                    core->airdodge_frame[i] == perfect_frame
+                    || (core->airdodge_frame[i] == perfect_frame+1 && core->short_hop)
+                ) {
+                    SFX_Play(303);
+                    break;
+                }
+            }
+            core->result = 1;
+        }
+        else if (hmn_data->TM.state_frame >= FAILFRAMES &&
+                core->airdodge_count != 0 &&
+                (hmn_data->state_id == ASID_JUMPF ||
+                hmn_data->state_id == ASID_JUMPB ||
+                hmn_data->state_id == ASID_ESCAPEAIR)) {
+            // failure
+            core->wd_attempted++;
+            SFX_PlayCommon(3);
+            core->result = 0;
+        }
+    }
+
+    // We need to wait until the wavedash finishes to reset in order to capture late LR presses
+    if (core->timer == 13) {
+        // Reset
+        core->result = -1;
+        core->timer = -1;
+        Fighter_ColAnim_Remove(hmn_data, 107); // remove sparkles
+
+        // Wavedash not attempted
+        if (core->airdodge_count == 0)
+            return;
+
+        // update timing
+        int timing = core->airdodge_frame[0] - (int)hmn_data->attr.jump_startup_time - 1;
+        for (int i = 1; i < core->airdodge_count; ++i) {
+            int new_timing = core->airdodge_frame[i] - (int)hmn_data->attr.jump_startup_time - 1;
+            if (timing < 0)
+                timing = new_timing;
+            else
+                break;
+        }
+
+        if (timing < 0)
+            sprintf(timing_text, "%df Early", -timing);
+        else if (timing > 0)
+            sprintf(timing_text, "%df Late", timing);
+        else
+            sprintf(timing_text, "Perfect");
+
+        // update angle
+        sprintf(angle_text, "%.1f", core->angle);
+
+        // update success rate
+        int success = core->wd_succeeded;
+        int attempted = core->wd_attempted;
+        float success_rate = (float)success * 100.f / (float)attempted;
+        sprintf(success_rate_text, "%d (%.2f%%)", success, success_rate);
+    }
+}

--- a/src/wavedash_common.h
+++ b/src/wavedash_common.h
@@ -1,0 +1,25 @@
+#ifndef _WAVEDASH_COMMON_H_
+#define _WAVEDASH_COMMON_H_
+
+#include "../MexTK/mex.h"
+
+typedef struct WavedashCore {
+    int timer;
+    int airdodge_count;
+    int airdodge_frame[8];
+    int result;
+    float angle;
+    int short_hop;
+    int wd_attempted;
+    int wd_succeeded;
+} WavedashCore;
+
+typedef struct WavedashCoreConfig {
+    int show_hud;
+    int short_hop_indicator;
+} WavedashCoreConfig;
+
+void WavedashCore_Think(WavedashCore *core, FighterData *hmn_data, const WavedashCoreConfig *cfg);
+void WavedashCore_DrawHUD(WavedashCore *core, FighterData *hmn_data, const WavedashCoreConfig *cfg, int pass);
+
+#endif // _WAVEDASH_COMMON_H_

--- a/src/xmdash.c
+++ b/src/xmdash.c
@@ -1,0 +1,224 @@
+#include "xmdash.h"
+
+static void Dash_ResetToStart(XmDashData *event_data, GOBJ *hmn);
+
+static int canvas;
+static Text *hud_time_text, *hud_best_text;
+
+void Retry(GOBJ *menu) {
+    stc_match->end_kind = MATCHENDKIND_RETRY;
+    stc_match->state = 3;
+    Match_EndVS();
+}
+
+void Exit(GOBJ *menu) {
+    stc_match->state = 3;
+    Match_EndVS();
+}
+
+void StartFreePractice(GOBJ *gobj) {
+    XmDashData *event_data = event_vars->event_gobj->userdata;
+    event_data->free_practice = 1;
+    Options_Main[OPT_FREEPRACTICE].disable = 1; // one-way toggle; grey it out
+    // drop any in-progress run
+    event_data->started = 0;
+    event_data->finished = 0;
+    event_data->run_frames = 0;
+    event_data->result_timer = 0;
+}
+
+void XmDash_OnChangeDistance(GOBJ *menu, int value) {
+    XmDashData *event_data = event_vars->event_gobj->userdata;
+    event_data->distance = XmDash_Dist[value];
+    // Defer the marker move + player reset to the next think frame (after unpause)
+    // so they happen together with the camera follow. Doing it here, in the paused
+    // menu, moves the player/marker while the camera is frozen — leaving them
+    // off-screen until unpause.
+    event_data->reset_pending = 1;
+}
+
+void Event_Init(GOBJ *gobj) {
+    XmDashData *event_data = gobj->userdata;
+    event_data->assets = Archive_GetPublicAddress(event_vars->event_archive, "wavedash");
+    event_data->core.timer = -1;
+    event_data->core.result = -1;
+    stc_match->end_kind = MATCHENDKIND_NONE;
+    GObj_AddGXLink(gobj, HUD_GX, 5, 0);
+
+    canvas = Text_CreateCanvas(2, 0, 0, 0, 0, GXLINK_HUD, 81, 19);
+    hud_time_text = Text_CreateText(2, canvas);
+    hud_time_text->kerning = 1; hud_time_text->align = 0; hud_time_text->use_aspect = 1;
+    hud_time_text->trans.X = 50; hud_time_text->trans.Y = 25;
+    hud_time_text->viewport_scale.X = 1; hud_time_text->viewport_scale.Y = 1;
+    Text_AddSubtext(hud_time_text, 0, 0, "-");
+    hud_best_text = Text_CreateText(2, canvas);
+    hud_best_text->kerning = 1; hud_best_text->align = 0; hud_best_text->use_aspect = 1;
+    hud_best_text->trans.X = 50; hud_best_text->trans.Y = 40;
+    hud_best_text->scale.X = 0.35; hud_best_text->scale.Y = 0.35;
+    hud_best_text->viewport_scale.X = 1; hud_best_text->viewport_scale.Y = 1;
+    Text_AddSubtext(hud_best_text, 0, 0, "-");
+    event_data->persist_best = Events_GetSavedScore(stc_memcard->EventBackup.event);
+}
+
+static void Finish_Spawn(XmDashData *event_data) {
+    GOBJ *gobj = GObj_Create(10, 11, 0);
+    JOBJ *jobj = JOBJ_LoadJoint(event_data->assets->target_jobj);
+    GObj_AddObject(gobj, 3, jobj);
+    GObj_AddGXLink(gobj, GXLink_Common, 5, 0);
+    jobj->trans.X = event_data->start_x + event_data->distance;
+    jobj->trans.Y = event_data->start_y; // track surface level (calibrated in T9)
+    jobj->trans.Z = 0.f;
+    JOBJ_SetMtxDirtySub(jobj);
+    event_data->finish_gobj = gobj;
+}
+
+static void Dash_ResetToStart(XmDashData *event_data, GOBJ *hmn) {
+    FighterData *hmn_data = hmn->userdata;
+    hmn_data->phys.pos.X = event_data->start_x;
+    hmn_data->phys.pos.Y = event_data->start_y;
+    hmn_data->phys.self_vel.X = 0.f;
+    hmn_data->phys.self_vel.Y = 0.f;
+    hmn_data->phys.self_vel_ground.X = 0.f; // clear run/dash ground momentum (the slide)
+    hmn_data->phys.self_vel_ground.Y = 0.f;
+    Fighter_EnterWait(hmn); // interrupt any skid/stop animation so the player is immediately controllable
+    event_data->started = 0;
+    event_data->finished = 0;
+    event_data->run_frames = 0;
+    event_data->result_timer = 0;
+}
+
+void Event_Think(GOBJ *event) {
+    XmDashData *event_data = event->userdata;
+    GOBJ *hmn = Fighter_GetGObj(0);
+    FighterData *hmn_data = hmn->userdata;
+
+    // First frame: move the player off the tall bat/sandbag platform (Y~38) to
+    // above the long flat track (Y~1.7), so the dash runs on the track.
+    if (event_vars->game_timer == 1)
+        hmn_data->phys.pos.X = XMDASH_START_X;
+
+    // One-time setup once the player lands on the track: capture the start
+    // (track-surface Y) + frame the camera + spawn the finish marker.
+    if (!event_data->initialized && hmn_data->phys.air_state == 0) {
+        event_data->initialized = 1;
+        event_data->start_x  = hmn_data->phys.pos.X;
+        event_data->start_y  = hmn_data->phys.pos.Y;
+        event_data->distance = XmDash_Dist[Options_Main[OPT_DISTANCE].val];
+        Match_SetNormalCamera(); // HRC fixes the camera; switch to normal fighter-follow
+        Fighter_UpdateCameraBox(hmn);
+        CmSubject *subject = hmn_data->camera_subject;
+        subject->boundleft_curr  = subject->boundleft_proj;
+        subject->boundright_curr = subject->boundright_proj;
+        Match_CorrectCamera();
+        Finish_Spawn(event_data);
+    }
+
+    // Reused wavedash timing HUD.
+    WavedashCoreConfig cfg = { .show_hud = Options_Main[OPT_HUD].val, .short_hop_indicator = 1 };
+    WavedashCore_Think(&event_data->core, hmn_data, &cfg);
+
+    // On HRC the player's camera subject is left disabled/limited, so the
+    // normal-mode camera never focuses the fighter. Force it active each frame
+    // (kind 0 = always focus; lcancel.c:652 uses kind=0 to focus on a subject).
+    if (hmn_data->camera_subject) {
+        hmn_data->camera_subject->kind = 0;
+        hmn_data->camera_subject->is_disable = 0;
+    }
+
+    // Live timer + best-time HUD (runs every frame, even before initialized,
+    // so the display is always visible; run_frames is 0 until a dash starts).
+    if (Pause_CheckStatus(1) != 2) {
+        if (event_data->free_practice) {
+            GXColor text_gold = {255, 211, 0, 255};
+            Text_SetText(hud_time_text, 0, "");
+            Text_SetText(hud_best_text, 0, "Free Practice");
+            Text_SetColor(hud_best_text, 0, &text_gold);
+        } else {
+            Text_SetText(hud_time_text, 0, "%.2fs", event_data->run_frames / 60.0f);
+            int dist_idx = Options_Main[OPT_DISTANCE].val;
+            int best = (dist_idx == XMDASH_DEFAULT_DIST_IDX && event_data->persist_best)
+                           ? event_data->persist_best : event_data->session_best[dist_idx];
+            if (best) {
+                GXColor text_white = {255, 255, 255, 255};
+                Text_SetText(hud_best_text, 0, "Best: %.2fs", best / 60.0f);
+                Text_SetColor(hud_best_text, 0, &text_white);
+            } else {
+                Text_SetText(hud_best_text, 0, "");
+            }
+        }
+    } else {
+        Text_SetText(hud_time_text, 0, "");
+        Text_SetText(hud_best_text, 0, "");
+    }
+
+    // Dash lifecycle only runs after the one-time grounded setup above.
+    if (!event_data->initialized)
+        return;
+
+    // Free practice: untimed, no finish/scoring — just the track + wavedash HUD.
+    if (event_data->free_practice)
+        return;
+
+    // Apply a deferred distance-change reset now that we're running again, so the
+    // marker move + teleport + camera follow all happen together this frame.
+    if (event_data->reset_pending) {
+        event_data->reset_pending = 0;
+        if (event_data->finish_gobj) {
+            JOBJ *jobj = event_data->finish_gobj->hsd_object;
+            jobj->trans.X = event_data->start_x + event_data->distance;
+            JOBJ_SetMtxDirtySub(jobj);
+        }
+        Dash_ResetToStart(event_data, hmn);
+        Fighter_UpdateCameraBox(hmn);
+    }
+
+    float finish_x = event_data->start_x + event_data->distance;
+
+    // Start the dash timer once the player moves past the start line.
+    if (!event_data->started && !event_data->finished &&
+        hmn_data->phys.pos.X > event_data->start_x + 1.0f) {
+        event_data->started = 1;
+        event_data->run_frames = 0;
+    }
+    if (event_data->started && !event_data->finished)
+        event_data->run_frames++;
+
+    // Finish when crossing the finish line.
+    if (event_data->started && !event_data->finished && hmn_data->phys.pos.X >= finish_x) {
+        event_data->finished = 1;
+        SFX_Play(249); // finish cue
+
+        int dist_idx = Options_Main[OPT_DISTANCE].val;
+        int t = event_data->run_frames;
+        if (event_data->session_best[dist_idx] == 0 || t < event_data->session_best[dist_idx])
+            event_data->session_best[dist_idx] = t;
+        if (dist_idx == XMDASH_DEFAULT_DIST_IDX) {
+            int event_id = stc_memcard->EventBackup.event;
+            Events_SetEventAsPlayed(event_id);
+            if (event_data->persist_best == 0 || t < event_data->persist_best) {
+                event_data->persist_best = t;
+                Events_StoreEventScore(event_id, t);
+                SFX_Play(325); // new-record cue (in addition to the finish SFX)
+            }
+        }
+    }
+
+    // After finishing, hold the result briefly then auto-teleport back to the
+    // start for fast iteration. Hold length tunable in T9.
+    if (event_data->finished) {
+        event_data->result_timer++;
+        if (event_data->result_timer >= 90) {
+            Dash_ResetToStart(event_data, hmn);
+            Fighter_UpdateCameraBox(hmn);
+        }
+    }
+}
+
+void HUD_GX(GOBJ *gobj, int pass) {
+    XmDashData *event_data = gobj->userdata;
+    FighterData *hmn_data = Fighter_GetGObj(0)->userdata;
+    WavedashCoreConfig cfg = { .show_hud = Options_Main[OPT_HUD].val, .short_hop_indicator = 1 };
+    WavedashCore_DrawHUD(&event_data->core, hmn_data, &cfg, pass);
+}
+
+EventMenu *Event_Menu = &Menu_Main;

--- a/src/xmdash.h
+++ b/src/xmdash.h
@@ -1,0 +1,100 @@
+#ifndef _XMDASH_H_
+#define _XMDASH_H_
+
+#include "../MexTK/mex.h"
+#include "events.h"
+#include "wavedash_common.h"
+
+#define XMDASH_START_X      80.0f    // start on the flat track, just right of the bat platform (HRC); calibrated in T9
+
+// Calibrated to HRC's distance signs: 600 units = the 200m sign (~3 units/m).
+static float XmDash_Dist[] = { 150.f, 300.f, 600.f };
+static const char *XmDash_DistText[] = { "50m", "100m", "200m" };
+#define XMDASH_DEFAULT_DIST_IDX 1   // default 100m
+
+typedef struct XmDashAssets {
+    JOBJDesc *hud;
+    void **hudmatanim;
+    JOBJDesc *target_jobj;
+    void **target_jointanim;
+    void **target_matanim;
+} XmDashAssets;
+
+typedef struct XmDashData {
+    EventDesc *event_desc;
+    XmDashAssets *assets;
+    WavedashCore core;
+    int   started;        // dash timer running
+    int   finished;       // crossed the finish this run
+    int   run_frames;     // elapsed frames since the dash started
+    int   result_timer;   // frames since finishing (result hold before auto-reset)
+    int   initialized;    // one-time grounded setup (start capture + marker) done
+    int   reset_pending;  // distance changed in the menu; apply the reset on the next think frame
+    float start_x;        // start line (captured on the first grounded frame)
+    float start_y;        // track-surface Y, for clean teleport-back
+    float distance;       // finish = start_x + distance
+    GOBJ *finish_gobj;    // finish-line marker model
+    int   session_best[countof(XmDash_Dist)]; // frames per distance; 0 = none
+    int   persist_best;                        // frames for the default (100m) distance; 0 = none
+    int   free_practice;                       // untimed practice mode; no finish/scoring
+} XmDashData;
+
+enum options_main {
+    OPT_RETRY,
+    OPT_FREEPRACTICE,
+    OPT_DISTANCE,
+    OPT_HUD,
+    OPT_EXIT,
+    OPT_COUNT
+};
+
+void Retry(GOBJ *menu);
+void Exit(GOBJ *menu);
+void StartFreePractice(GOBJ *gobj);
+void XmDash_OnChangeDistance(GOBJ *menu, int value);
+void Event_Init(GOBJ *gobj);
+void Event_Think(GOBJ *event);
+void HUD_GX(GOBJ *gobj, int pass);
+
+static EventOption Options_Main[OPT_COUNT] = {
+    {
+        .kind = OPTKIND_FUNC,
+        .name = "Retry",
+        .desc = { "Restart the dash. Or press Z while paused." },
+        .OnSelect = Retry,
+    },
+    {
+        .kind = OPTKIND_FUNC,
+        .name = "Enable Free Practice",
+        .desc = { "Untimed practice - no finish line or scoring." },
+        .OnSelect = StartFreePractice,
+    },
+    {
+        .kind = OPTKIND_STRING,
+        .name = "Distance",
+        .desc = { "Select the dash distance." },
+        .value_num = countof(XmDash_DistText),
+        .values = XmDash_DistText,
+        .val = XMDASH_DEFAULT_DIST_IDX,
+        .OnChange = XmDash_OnChangeDistance,
+    },
+    {
+        .kind = OPTKIND_TOGGLE,
+        .name = "HUD",
+        .val = 1,
+        .desc = {"Toggle visibility of the wavedash HUD."},
+    },
+    {
+        .kind = OPTKIND_FUNC,
+        .name = "Exit",
+        .desc = { "Return to the Event Selection Screen." },
+        .OnSelect = Exit,
+    },
+};
+static EventMenu Menu_Main = {
+    .name = "100m Dash",
+    .option_num = countof(Options_Main),
+    .options = Options_Main,
+};
+
+#endif // _XMDASH_H_


### PR DESCRIPTION
Adds a new Minigames event, **100m Dash** — a timed sprint down the Home Run Contest track.

## Motivation
I love the wavedash training, but I often want to focus on input accuracy without having to deal with ledges / falling off the stage. That got me thinking there's no event to directly test your lateral speed with a character. For Samus in particular, the fastest way to move horizontally (without superwavedashing) is to dash-then-wavedash repeatedly, and most stages aren't long or flat enough to do that repeatedly without having to turn around or deal with ledges. I thought something that gives you a clear metric — "you covered this distance in X time" — could be fun, and a good place to practice this sort of technique.

**The ask:** Is this an event that y'all would be interested in having/merging? I'm opening it before polishing further (a couple of follow-ups are noted at the bottom) to gauge interest first.

## What it does
- Loads the HRC stage and starts the player on the flat track.
- Sprint from a start line to a selectable-distance finish (50m / 100m / 200m, aligned to the in-stage distance signs); 100m is the default.
- Reuses the wavedash timing HUD (early/perfect/late bar + Timing/Angle/Success-Rate).
- Run timer + best time; persists the 100m best as the event score (Event Select shows it via SCORETYPE_TIME); 50m/200m are session bests.
- Camera follows the player; untimed Free Practice mode.

## Implementation notes (HRC-specific bits worth a look)
- **Shared module (separate commit):** extracted wavedash's airdodge-timing + HUD into `wavedash_common.{c,h}`, behaviour-preserving, so wavedash and this event share it.
- **Stage:** external id **84** maps to `GRKIND_HOMERUN`, added as `GRKINDEXT_HOMERUN`.
- **callbackPriority 15:** the reused frame-precise timing detection only works at 15 (like wavedash/ledgedash), not the minigame default of 3.
- **Camera:** HRC renders through its own camera that mirrors the match camera (`grhomerun.c` `fn_8021EB10`) and leaves the player's camera subject disabled — so `Match_SetNormalCamera()` + forcing `camera_subject->kind=0/is_disable=0` makes the match camera (and HRC's mirror) follow the fighter.

## Testing
Built with the native toolchain (arm64 macOS notes added to DEVELOPMENT.md) and playtested in Dolphin: all distances, scoring/persistence, camera-follow, Free Practice, Exit/Retry, plus a wavedash-event regression check for the refactor.

## Planned follow-ups (pending interest)
- "Ready… Go" countdown start.
- A mirrored right-to-left direction.