### PR TITLE
Fix DK cargo throw DI in Combo Training

### DIFF
--- a/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
+++ b/ASM/training-mode/Custom Events/Custom Event Code - Rewrite.asm
@@ -5221,9 +5221,16 @@ ComboTrainingDecideStickAngle_ComboDI_GetXY:
 
     # If In a Throw, Always DI The Direction Of The Angle
     lwz r3, 0x10(r29)
-    cmpwi r3, 0xEF
+    cmpwi r3, ASID_ThrownF
+    blt ComboTrainingDecideStickAngle_ComboDI_AdjustDirection_CheckCargoThrow
+    cmpwi r3, ASID_ThrownLwWomen
+    ble ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow
+
+ComboTrainingDecideStickAngle_ComboDI_AdjustDirection_CheckCargoThrow:
+    # DK's cargo throws live in their own action state range
+    cmpwi r3, ASID_ThrownFF
     blt ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionNoThrow
-    cmpwi r3, 0xF3
+    cmpwi r3, ASID_ThrownFLw
     bgt ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionNoThrow
 
 ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow:
@@ -5232,7 +5239,7 @@ ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow:
     b ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow_RightSide
 
 ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow_Above90:
-    cmpwi r3, 269
+    cmpwi r24, 269
     blt ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow_LeftSide
 
 ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow_RightSide:
@@ -5402,11 +5409,19 @@ ComboTrainingDecideStickAngle_ConvertAngle_Exit:
 ComboTrainingCheckForThrowAngle:
     # Check If In Throw First (Must Retrieve Angle Manually)
     lwz r3, 0x10(r29)                                   # CPU AS
-    cmpwi r3, 0xEF
+    cmpwi r3, ASID_ThrownF
+    blt ComboTrainingCheckForThrowAngle_CheckCargoThrow
+    cmpwi r3, ASID_ThrownLwWomen
+    ble ComboTrainingCheckForThrowAngle_GetAngle
+
+ComboTrainingCheckForThrowAngle_CheckCargoThrow:
+    # DK's cargo throws live in their own action state range
+    cmpwi r3, ASID_ThrownFF
     blt ComboTrainingCheckForThrowAngle_NoThrow
-    cmpwi r3, 0xF3
+    cmpwi r3, ASID_ThrownFLw
     bgt ComboTrainingCheckForThrowAngle_NoThrow
 
+ComboTrainingCheckForThrowAngle_GetAngle:
     # Get Throw Angle
     addi r4, r27, 0xdf4                                 # P1 Throw Hitbox Info?
     lwz r3, 0x20(r4)                                    # Throw Angle


### PR DESCRIPTION
## Problem

The DK cargo throw DI fix from cd7beb5 works in Lab but not in Combo Training. With DI set to Survival DI or Combo DI, the CPU DIs DK's cargo throws in a direction unrelated to the actual throw angle.

## Root cause

cd7beb5 fixed the C lab event (`src/lab.c`). 2f9f6cf then ported the action state *classification* over to the Combo Training assembly, but not the *throw angle lookup* — and the commit name ("initial work to get cargo throws working in combo training") is honest about being unfinished.

DK's cargo throws live in their own action state range, `ThrownFF`..`ThrownFLw` (`0x10F`..`0x112`), separate from the normal `ThrownF`..`ThrownLwWomen` (`0xEF`..`0xF3`). Two spots still hardcoded the normal range:

1. **`ComboTrainingCheckForThrowAngle`** — returned `-1` for cargo throws, so both `Survival DI` and `Combo DI` fell through to `lwz r3, 0x1848(r29)` (the stored knockback angle), which is never populated during a throw. This is the visible bug.
2. **`ComboTrainingDecideStickAngle_ComboDI`** — the "if in a throw, always DI the direction of the angle" gate skipped cargo throws for the same reason.

## Changes

Both gates now accept the cargo throw range in addition to the normal one. Normal throws take exactly the same path as before.

This also fixes a typo one line below the second gate: `ComboTrainingDecideStickAngle_ComboDI_AdjustDirectionInThrow_Above90` compared `r3` — still holding the action state from the gate above — against `269`, rather than `r24`, which holds the backed up angle. Normal throw states are 239–243, so this always fell through to the LeftSide branch; since no throw has an angle >= 269, switching to `r24` is a no-op for every existing throw, and is required for cargo throws, whose states are 271–274.

## Testing

Built and tested in-game on NTSC-U.

- Combo Training, P1 = Donkey Kong, DI set to **Survival DI** or **Combo DI**
- Grab → cargo carry → cargo **up / back / down** throw
- CPU DI now matches what the same throw and DI setting produce in Lab

DI behaviors that don't consume the throw angle (No DI, Slight DI, Down and Away, truly random) are unaffected, as are all non-cargo throws.

## Verification



https://github.com/user-attachments/assets/65c23533-675a-4f31-8727-f8a67c3c623d

